### PR TITLE
fix(transfer): Refuse to write a tree through a symlinked destination

### DIFF
--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -201,7 +201,7 @@ func (e endpoints) copyTree(ctx context.Context, absSrc, absDst string, cfg invo
 		return err
 	}
 
-	if err := e.makeDir(absDst); err != nil {
+	if err := e.makeRoot(absDst); err != nil {
 		return err
 	}
 
@@ -247,7 +247,7 @@ func (e endpoints) walk(ctx context.Context, srcDir, dstDir, rel string, dirMode
 		}
 
 		if info.IsDir() {
-			if err := e.makeDir(dstPath); err != nil {
+			if err := e.makeChildDir(dstPath); err != nil {
 				return err
 			}
 
@@ -293,8 +293,14 @@ func (e endpoints) checkContained(srcDir, srcPath, dstDir, dstPath, name string)
 	return nil
 }
 
-// makeDir creates target as a directory, merging with an existing one.
-func (e endpoints) makeDir(target string) error {
+// makeRoot creates the transfer's destination root, merging with whatever
+// is already there.
+//
+// A root reached through a symbolic link is followed: the caller named
+// this path, so where it leads is the caller's own choice — pointing a
+// stable name at the current release directory is the ordinary way to
+// deploy, and refusing it would break that.
+func (e endpoints) makeRoot(target string) error {
 	if err := e.dst.Mkdir(target); err != nil {
 		if info, statErr := e.dst.Stat(target); statErr == nil && info.IsDir() {
 			return nil
@@ -304,6 +310,44 @@ func (e endpoints) makeDir(target string) error {
 	}
 
 	return nil
+}
+
+// makeChildDir creates a directory the walk discovered inside the tree,
+// merging with a directory already there but refusing a symbolic link.
+//
+// Nobody named this path. It exists because the source tree has a
+// directory at it, and the destination is only asked whether something is
+// there already. Merging into a link would send the rest of the tree
+// wherever the link points, outside the root the caller chose, while every
+// path this engine forms still reads as contained — the containment check
+// compares names, and the name never leaves the root. So the link is
+// refused here, where it is still a name rather than a destination.
+//
+// This closes the entry already at the destination. It does not defend
+// against one substituted between this check and the write that follows;
+// that needs the resolution and the write to be one operation, which the
+// FS abstraction does not currently express.
+func (e endpoints) makeChildDir(target string) error {
+	mkdirErr := e.dst.Mkdir(target)
+	if mkdirErr == nil {
+		return nil
+	}
+
+	info, err := e.dst.Lstat(target)
+	if err != nil {
+		return mkdirErr
+	}
+
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf(
+			"destination %q is a symbolic link; refusing to write the transferred tree through it", target)
+	}
+
+	if info.IsDir() {
+		return nil
+	}
+
+	return mkdirErr
 }
 
 // copyEntry copies one non-directory entry according to the shared

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -155,6 +155,65 @@ func TestWalkAcceptsNamesLegalOnTheSourceSide(t *testing.T) {
 	assert.Equal(t, "payload", string(got))
 }
 
+// TestWalkRefusesASymlinkedDestinationDirectory pins the containment
+// boundary against a link already at the destination. The containment
+// check compares names, and a name never leaves the root, so a link
+// standing where the tree expects a directory would carry the transfer
+// out of the destination while every check still read as contained.
+func TestWalkRefusesASymlinkedDestinationDirectory(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	srcDir := filepath.Join(base, "src")
+	dstDir := filepath.Join(base, "dst")
+	outside := filepath.Join(base, "outside")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "sub"), 0o755), "source tree")
+	require.NoError(t,
+		os.WriteFile(filepath.Join(srcDir, "sub", "payload.txt"), []byte("payload"), 0o600), "writing fixture")
+	require.NoError(t, os.MkdirAll(outside, 0o755), "outside directory")
+	require.NoError(t, os.MkdirAll(dstDir, 0o755), "destination")
+
+	// The destination already holds a link where the source has a
+	// directory: the shape of the source decides this path, not the caller.
+	require.NoError(t, os.Symlink(outside, filepath.Join(dstDir, "sub")), "symlink")
+
+	err := transfer.Copy(t.Context(), transfer.HostFS{}, srcDir, transfer.HostFS{}, dstDir, invoke.TransferConfig{})
+	require.Error(t, err, "a transfer through a symlinked destination directory reported success")
+
+	assert.ErrorContains(t, err, "symbolic link", "the error does not say why the transfer stopped")
+
+	assert.NoFileExists(t, filepath.Join(outside, "payload.txt"),
+		"the transfer wrote through the link, outside the destination the caller named")
+}
+
+// TestCopyFollowsASymlinkedDestinationRoot pins the other half of the
+// rule, so the containment fix is not later widened into a regression: the
+// root is the one path the caller named, and pointing a stable name at the
+// current release directory is the ordinary way to deploy.
+func TestCopyFollowsASymlinkedDestinationRoot(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	srcDir := filepath.Join(base, "src")
+	release := filepath.Join(base, "release")
+	current := filepath.Join(base, "current")
+
+	require.NoError(t, os.MkdirAll(srcDir, 0o755), "source tree")
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "app.txt"), []byte("payload"), 0o600), "writing fixture")
+	require.NoError(t, os.MkdirAll(release, 0o755), "release directory")
+	require.NoError(t, os.Symlink(release, current), "symlink")
+
+	require.NoError(t,
+		transfer.Copy(t.Context(), transfer.HostFS{}, srcDir, transfer.HostFS{}, current, invoke.TransferConfig{}),
+		"a transfer to a symlinked root the caller named must be delivered")
+
+	got, err := os.ReadFile(filepath.Join(release, "app.txt"))
+	require.NoError(t, err, "reading transferred file")
+
+	assert.Equal(t, "payload", string(got))
+}
+
 // TestCopyRejectsCanceledContext checks the engine refuses before it
 // creates anything, including for a source with no entries to check.
 func TestCopyRejectsCanceledContext(t *testing.T) {

--- a/local/files_test.go
+++ b/local/files_test.go
@@ -270,6 +270,33 @@ func TestSymlinkFollowRejectsEscapes(t *testing.T) {
 	assert.ErrorContains(t, err, "escape.txt", "the error does not name the offending link")
 }
 
+// TestUploadRefusesASymlinkedDestinationDirectory is the end-to-end shape
+// of the containment rule: a link already at the destination, standing
+// where the source tree has a directory, must stop the upload rather than
+// carry it outside the destination the caller named.
+func TestUploadRefusesASymlinkedDestinationDirectory(t *testing.T) {
+	t.Parallel()
+
+	env := newEnv(t)
+
+	base := t.TempDir()
+	srcDir := filepath.Join(base, "src")
+	dstDir := filepath.Join(base, "dst")
+	outside := filepath.Join(base, "outside")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "sub"), 0o755), "source tree")
+	writeFixture(t, filepath.Join(srcDir, "sub"), "payload.txt", "payload", modeDefault)
+	require.NoError(t, os.MkdirAll(outside, 0o755), "outside directory")
+	require.NoError(t, os.MkdirAll(dstDir, 0o755), "destination")
+	require.NoError(t, os.Symlink(outside, filepath.Join(dstDir, "sub")), "symlink")
+
+	err := env.Upload(t.Context(), srcDir, dstDir)
+	require.Error(t, err, "an upload through a symlinked destination directory reported success")
+
+	assert.NoFileExists(t, filepath.Join(outside, "payload.txt"),
+		"the upload wrote through the link, outside the destination the caller named")
+}
+
 func TestSymlinkSkipOmitsLinks(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Wave 0 (security hotfix), PR 1 of 3. Closes the transfer-engine half of the symlink containment escape found in the audit.

## The bug

The containment check compares *names*, and a name formed by joining an entry onto the destination never leaves the root. So a link already at the destination escaped it entirely: where the source tree had a directory and the destination had a symbolic link of the same name, `makeDir` `Stat`ed the existing entry (following the link), saw a directory, and merged into it — writing the rest of the tree wherever the link pointed.

Reproduced before the fix, on the `local` provider:

```
Upload(src, dst)   # dst/sub is a pre-existing symlink -> ../OUTSIDE
=> OUTSIDE/payload.txt written, err == nil
```

Silent success, outside the destination the caller named. This defeats the design's "symlink-aware containment checks, not lexical prefix".

Because `internal/transfer` is the shared engine, this affected the `local` provider in both directions, the host side of every `ssh` download, and `fake`. (The `docker` provider has the same class of bug in its own `untar.go` path — that is PR 2, separate module and separate code.)

## The fix

The distinction the code was missing is **who chose the path**:

- The **root** is the one path the caller named, so a root reached through a link is still followed. Pointing a stable name at the current release directory is the ordinary way to deploy, and refusing it would break that. (`makeRoot`)
- **Every directory below it** comes from the shape of the source tree, not from the caller. A link standing where one of those belongs is refused by name; an ordinary directory still merges. (`makeChildDir`, `Lstat`-based)

No interface change: `Lstat` was already on `MetaFS`, so `sftpFS` and the fake's `fsView` are covered without touching them.

### Scope, stated honestly

This closes the entry *already* at the destination. It does not defend against one substituted between the check and the write — that needs resolution and write to be a single operation, which the `FS` abstraction does not currently express. The doc comment says so rather than implying more than it does.

## Verification

- Both new tests **fail against the previous behaviour**, reporting the silent success — they are provably able to fail, per this repo's standard.
- `just check` — green (lint 0 issues in both modules, race tests, Windows cross-build, tidy).
- `go test -tags openssh -race ./ssh/` against a real OpenSSH server — green.
- `go test -tags docker -race ./...` against a live daemon — green.
- The original audit repro now fails closed with an error naming the path and the reason.

`TestCopyFollowsASymlinkedDestinationRoot` deliberately pins the *other* half of the rule, so the fix is not later widened into a regression that breaks the deploy pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)