### PR TITLE
fix(docker): Contain extraction against symlinked parents

### DIFF
--- a/docker/untar.go
+++ b/docker/untar.go
@@ -49,7 +49,7 @@ func extractTree(ctx context.Context, tr *tar.Reader, dst string, cfg invoke.Tra
 		}
 
 		if header.Typeflag == tar.TypeDir {
-			if err := os.MkdirAll(target, 0o755); err != nil {
+			if err := ensureContainedDir(dst, target); err != nil {
 				return err
 			}
 
@@ -82,10 +82,10 @@ func extractEntry(
 ) error {
 	switch header.Typeflag {
 	case tar.TypeReg:
-		return extractFile(ctx, tr, target, header, cfg)
+		return extractFile(ctx, tr, dst, target, header, cfg)
 
 	case tar.TypeSymlink:
-		return extractSymlink(header.Linkname, target)
+		return extractSymlink(dst, header.Linkname, target)
 
 	case tar.TypeLink:
 		return extractHardlink(dst, header.Linkname, target)
@@ -118,6 +118,104 @@ func entryPath(dst, name string) (string, error) {
 	return target, nil
 }
 
+// containedComponents lists the paths from the destination root down to p,
+// one per component, so each can be examined before it is walked through.
+func containedComponents(dst, p string) ([]string, error) {
+	rel, err := filepath.Rel(dst, p)
+	if err != nil {
+		return nil, err
+	}
+
+	if rel == "." {
+		return nil, nil
+	}
+
+	parts := strings.Split(rel, string(filepath.Separator))
+	paths := make([]string, 0, len(parts))
+	current := dst
+
+	for _, name := range parts {
+		current = filepath.Join(current, name)
+		paths = append(paths, current)
+	}
+
+	return paths, nil
+}
+
+// ensureContainedDir creates the directories from the destination root
+// down to dir, refusing any component already present as a symbolic link.
+//
+// An archive names its own entries and need not order them, so an entry's
+// parent is usually created here rather than by a directory entry of its
+// own. Creating it a component at a time is what makes the check possible:
+// MkdirAll resolves the whole path it is given, and a link among those
+// components would be followed before anything could object to it.
+func ensureContainedDir(dst, dir string) error {
+	components, err := containedComponents(dst, dir)
+	if err != nil {
+		return err
+	}
+
+	for _, component := range components {
+		if err := makeContainedDir(component); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// makeContainedDir creates one directory inside the destination, merging
+// with a directory already there and refusing a symbolic link.
+//
+// The archive chose this path. A link standing where it expects a
+// directory would carry the rest of the extraction wherever the link
+// points, while every name the extractor forms still read as contained.
+func makeContainedDir(dir string) error {
+	mkdirErr := os.Mkdir(dir, 0o755)
+	if mkdirErr == nil {
+		return nil
+	}
+
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return mkdirErr
+	}
+
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("archive entry %q is a symbolic link; refusing to extract through it", dir)
+	}
+
+	if info.IsDir() {
+		return nil
+	}
+
+	return mkdirErr
+}
+
+// verifyContained reports whether any component between the destination
+// root and p is a symbolic link, for a path the archive names but the
+// extractor does not create.
+func verifyContained(dst, p string) error {
+	components, err := containedComponents(dst, p)
+	if err != nil {
+		return err
+	}
+
+	for _, component := range components {
+		info, err := os.Lstat(component)
+		if err != nil {
+			return err
+		}
+
+		if info.Mode()&fs.ModeSymlink != 0 {
+			return fmt.Errorf("archive entry %q resolves through the symbolic link %q", p, component)
+		}
+	}
+
+	return nil
+}
+
 // headerMode is the mode an extracted entry should carry.
 func headerMode(header *tar.Header, cfg invoke.TransferConfig) fs.FileMode {
 	if cfg.Mode != nil {
@@ -128,8 +226,21 @@ func headerMode(header *tar.Header, cfg invoke.TransferConfig) fs.FileMode {
 }
 
 // extractFile writes one regular file, reporting progress as bytes land.
-func extractFile(ctx context.Context, tr io.Reader, target string, header *tar.Header, cfg invoke.TransferConfig) error {
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+func extractFile(
+	ctx context.Context,
+	tr io.Reader,
+	dst, target string,
+	header *tar.Header,
+	cfg invoke.TransferConfig,
+) error {
+	if err := ensureContainedDir(dst, filepath.Dir(target)); err != nil {
+		return err
+	}
+
+	// A link already occupying the target would be followed by the create
+	// below, writing through it. Extraction replaces what it finds, so the
+	// link goes rather than the file it points at.
+	if err := removeSymlink(target); err != nil {
 		return err
 	}
 
@@ -177,9 +288,28 @@ func archiveRootPrefix(name string) string {
 	return ""
 }
 
+// removeSymlink clears a symbolic link occupying an extraction target, so
+// creating the entry there cannot follow it out of the tree.
+func removeSymlink(target string) error {
+	info, err := os.Lstat(target)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if info.Mode()&fs.ModeSymlink == 0 {
+		return nil
+	}
+
+	return os.Remove(target)
+}
+
 // extractSymlink recreates a link, replacing whatever occupies the path.
-func extractSymlink(linkTarget, target string) error {
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+func extractSymlink(dst, linkTarget, target string) error {
+	if err := ensureContainedDir(dst, filepath.Dir(target)); err != nil {
 		return err
 	}
 
@@ -209,7 +339,14 @@ func extractHardlink(dst, linkName, target string) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+	// The source is a path the archive names rather than one the extractor
+	// creates, so a link among its components would reach a file outside
+	// the tree and hard-link it back in.
+	if err := verifyContained(dst, source); err != nil {
+		return err
+	}
+
+	if err := ensureContainedDir(dst, filepath.Dir(target)); err != nil {
 		return err
 	}
 

--- a/docker/untar_test.go
+++ b/docker/untar_test.go
@@ -1,0 +1,178 @@
+package docker
+
+import (
+	"archive/tar"
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ruffel/invoke"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tarEntry describes one member of an archive built for these tests. An
+// archive arrives from the daemon, but the daemon is not the only thing
+// that can produce one, so these are written by hand.
+type tarEntry struct {
+	name     string
+	typeflag byte
+	linkname string
+	body     string
+	mode     int64
+}
+
+// buildArchive assembles the entries into an archive, in order.
+func buildArchive(t *testing.T, entries []tarEntry) *tar.Reader {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	writer := tar.NewWriter(&buf)
+
+	for _, entry := range entries {
+		mode := entry.mode
+		if mode == 0 {
+			mode = 0o644
+		}
+
+		require.NoError(t, writer.WriteHeader(&tar.Header{
+			Name:     entry.name,
+			Typeflag: entry.typeflag,
+			Linkname: entry.linkname,
+			Mode:     mode,
+			Size:     int64(len(entry.body)),
+		}), "writing the header for %q", entry.name)
+
+		if entry.body != "" {
+			_, err := writer.Write([]byte(entry.body))
+			require.NoError(t, err, "writing the body of %q", entry.name)
+		}
+	}
+
+	require.NoError(t, writer.Close(), "closing the archive")
+
+	return tar.NewReader(&buf)
+}
+
+// TestExtractRefusesToWriteThroughASymlinkedParent pins the containment
+// boundary against the archive itself. Each entry's name is checked
+// against the destination, and both of these names pass: what leaves the
+// destination is not the name but the link the first entry plants, which
+// the second one is then written through.
+func TestExtractRefusesToWriteThroughASymlinkedParent(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	dst := filepath.Join(base, "dst")
+	outside := filepath.Join(base, "outside")
+
+	require.NoError(t, os.MkdirAll(dst, 0o755), "destination")
+	require.NoError(t, os.MkdirAll(outside, 0o755), "outside directory")
+
+	archive := buildArchive(t, []tarEntry{
+		{name: "root/", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "root/sub", typeflag: tar.TypeSymlink, linkname: outside},
+		{name: "root/sub/payload.txt", typeflag: tar.TypeReg, body: "payload"},
+	})
+
+	err := extractTree(t.Context(), archive, dst, invoke.TransferConfig{})
+	require.Error(t, err, "an extraction through a planted link reported success")
+
+	assert.ErrorContains(t, err, "symbolic link", "the error does not say why the extraction stopped")
+
+	assert.NoFileExists(t, filepath.Join(outside, "payload.txt"),
+		"the extraction wrote through the planted link, outside the destination")
+}
+
+// TestExtractReplacesALinkAtTheTargetRatherThanWritingThroughIt covers the
+// same escape one component further down, where the link occupies the
+// entry's own path rather than a parent of it.
+func TestExtractReplacesALinkAtTheTargetRatherThanWritingThroughIt(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	dst := filepath.Join(base, "dst")
+	outside := filepath.Join(base, "outside")
+
+	require.NoError(t, os.MkdirAll(dst, 0o755), "destination")
+	require.NoError(t, os.MkdirAll(outside, 0o755), "outside directory")
+
+	victim := filepath.Join(outside, "victim.txt")
+	require.NoError(t, os.WriteFile(victim, []byte("original"), 0o600), "writing fixture")
+
+	archive := buildArchive(t, []tarEntry{
+		{name: "root/", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "root/f.txt", typeflag: tar.TypeSymlink, linkname: victim},
+		{name: "root/f.txt", typeflag: tar.TypeReg, body: "overwritten"},
+	})
+
+	require.NoError(t, extractTree(t.Context(), archive, dst, invoke.TransferConfig{}),
+		"replacing a link with a file is an ordinary extraction")
+
+	got, err := os.ReadFile(victim)
+	require.NoError(t, err, "reading the file the link pointed at")
+
+	assert.Equal(t, "original", string(got),
+		"the extraction wrote through the link at its own target")
+}
+
+// TestExtractRefusesAHardlinkResolvingThroughASymlink covers the path an
+// archive names but the extractor does not create: a hard link's source
+// resolves at link time, so a planted link among its components would
+// reach a file outside the tree and carry it back in.
+func TestExtractRefusesAHardlinkResolvingThroughASymlink(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	dst := filepath.Join(base, "dst")
+	outside := filepath.Join(base, "outside")
+
+	require.NoError(t, os.MkdirAll(dst, 0o755), "destination")
+	require.NoError(t, os.MkdirAll(outside, 0o755), "outside directory")
+	require.NoError(t,
+		os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o600), "writing fixture")
+
+	archive := buildArchive(t, []tarEntry{
+		{name: "root/", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "root/sub", typeflag: tar.TypeSymlink, linkname: outside},
+		{name: "root/stolen.txt", typeflag: tar.TypeLink, linkname: "root/sub/secret.txt"},
+	})
+
+	err := extractTree(t.Context(), archive, dst, invoke.TransferConfig{})
+	require.Error(t, err, "a hard link resolving through a planted link reported success")
+
+	assert.NoFileExists(t, filepath.Join(dst, "root", "stolen.txt"),
+		"a file outside the tree was hard-linked into it")
+}
+
+// TestExtractCarriesAnOrdinaryTree guards the other side of the rule: the
+// containment checks must not refuse the trees that motivated preserving
+// links in the first place.
+func TestExtractCarriesAnOrdinaryTree(t *testing.T) {
+	t.Parallel()
+
+	dst := t.TempDir()
+
+	archive := buildArchive(t, []tarEntry{
+		{name: "root/", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "root/lib/", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "root/lib/real.txt", typeflag: tar.TypeReg, body: "payload"},
+		{name: "root/link.txt", typeflag: tar.TypeSymlink, linkname: "lib/real.txt"},
+	})
+
+	require.NoError(t, extractTree(t.Context(), archive, dst, invoke.TransferConfig{}),
+		"an ordinary tree must still extract")
+
+	got, err := os.ReadFile(filepath.Join(dst, "root", "lib", "real.txt"))
+	require.NoError(t, err, "reading the extracted file")
+
+	assert.Equal(t, "payload", string(got))
+
+	info, err := os.Lstat(filepath.Join(dst, "root", "link.txt"))
+	require.NoError(t, err, "the link was not extracted")
+
+	assert.NotZero(t, info.Mode()&fs.ModeSymlink, "the link was not preserved as a link")
+}


### PR DESCRIPTION
Wave 0 (security hotfix), PR 2 of 3. Independent of #2 — different module, different code path, either order.

## The bug

An archive names its own entries, and `entryPath` checks each name against the destination. Both names in this archive pass:

```
root/sub              -> symlink to /some/outside/dir
root/sub/payload.txt  -> regular file
```

What leaves the destination is not the *name* but the *link the archive plants*. `MkdirAll` is what made it reachable: it resolves the whole path it is given, so the planted link was followed before anything could object, and `payload.txt` landed outside the tree. `O_CREATE|O_TRUNC` did the same for a link occupying an entry's own target, and a hard link's source resolves at link time, so a planted link among its components reaches a file outside the tree and carries it back in.

Extraction runs into a fresh staging directory, so this is not about pre-existing state at the destination — the archive supplies both halves of the attack itself. A malicious or compromised daemon (any remote `DOCKER_HOST`) fully controls that stream. The file's own comment already said the daemon is not the only thing that can produce an archive; the check just did not live up to it.

## The fix

Create the path a component at a time instead of with `MkdirAll`, refusing any component already present as a symbolic link. Clear a link occupying an entry's own target rather than creating through it — which is what `tar` does before extracting over an existing entry. Check a hard link's source the same way, since the extractor never creates that path.

No `O_NOFOLLOW`: it does not exist on Windows and this module must keep cross-building. The check is portable `Lstat`-per-component.

### What this deliberately does not change

My audit note said I would also validate `header.Linkname`. I did not, and the reason matters: the shared engine (`internal/transfer`) preserves link targets verbatim too, so narrowing it only here would make the two providers disagree about what `SymlinkPreserve` means — the exact divergence this library exists to prevent. Downloading a container still reproduces a planted `link -> /etc/shadow`. That is a semantics decision for `SymlinkPreserve` across both engines, and belongs in its own PR with a contract covering both. **This PR closes the write escape**, which is the arbitrary-overwrite vector.

Same honesty as #2 on TOCTOU: this closes what is already there at check time, not an entry substituted between the check and the write.

## Verification

- The three escape tests **fail against the previous behaviour**, each reporting the silent success; the fourth (an ordinary tree with a relative link) passes both ways and guards against over-refusal.
- Tests build their archives **by hand rather than through a daemon**, so this escape is now covered in the ordinary `go test ./...` lane — no `-tags docker` required.
- `just check` green (lint 0 issues both modules, race, Windows cross-build, tidy).
- `go test -tags docker -race ./...` against a live daemon — green.