### PR TITLE
fix: Refuse to retry an outcome that is also terminal

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -78,6 +78,13 @@ func (e *ExitError) Error() string {
 //
 // It is the only retryable family in the taxonomy: the failure is
 // environmental, not a verdict about the command.
+//
+// It is not a wrapper for one. Because it unwraps, a TransportError
+// carrying an [ExitError] or one of the sentinels above belongs to both
+// families at once, and the outcome it carries is the one that decides:
+// such an error is terminal and is never retried. A provider with a
+// verdict about the command should return that verdict rather than dress
+// it as a transport failure.
 type TransportError struct {
 	// Op names the operation that failed: "start", "wait", "upload",
 	// "download", "lookpath".

--- a/executor.go
+++ b/executor.go
@@ -288,10 +288,45 @@ func (e *Executor) backoffWait(ctx context.Context, cfg execConfig, n int) error
 // family the executor retries. Everything else (exit errors, cancellation,
 // closed environments, unsupported features, missing binaries) is
 // terminal, so retrying must be earned by explicit classification.
+//
+// Belonging to that family is necessary but not sufficient. A
+// [TransportError] unwraps, so one wrapping a terminal outcome answers to
+// both families at once: every assertion about the inner error still
+// holds, and the classifier still reads the outer one. Retry asks a single
+// question — might the command not have run? — and an outcome saying it
+// did run answers it whatever else the error also says. So the terminal
+// reading wins, and a provider cannot obtain a second execution of an
+// arbitrary command by wrapping the first one's verdict.
 func retryable(err error) bool {
 	var te *TransportError
 
-	return errors.As(err, &te)
+	return errors.As(err, &te) && !terminal(err)
+}
+
+// terminal reports whether err carries an outcome that forecloses running
+// the command again: it ran, or it could not run for a reason that asking
+// again will not change.
+//
+// Cancellation is deliberately absent. A provider's own per-attempt
+// deadline produces a context error inside a genuine transport failure,
+// and treating that as terminal would strand a retry the caller wanted.
+// The caller's own cancellation needs no help from here: the backoff
+// before the next attempt returns the context's error, so the command is
+// never started again regardless of how this reads.
+func terminal(err error) bool {
+	var exitErr *ExitError
+
+	if errors.As(err, &exitErr) {
+		return true
+	}
+
+	for _, sentinel := range []error{ErrClosed, ErrNotFound, ErrNotSupported, ErrInvalidWorkdir} {
+		if errors.Is(err, sentinel) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // applySudo rewrites cmd to run through sudo, or returns it unchanged when

--- a/executor_test.go
+++ b/executor_test.go
@@ -141,6 +141,64 @@ func TestRetryOnlyTransportErrors(t *testing.T) {
 	}
 }
 
+// TestTerminalOutcomeWrappedInTransportIsNotRetried pins the rule that
+// decides whether an arbitrary command may be run a second time.
+//
+// A TransportError unwraps, so one wrapping a terminal outcome satisfies
+// every assertion about the outcome it carries while still answering to
+// the retryable family. A provider that reports a command's own verdict in
+// that shape would otherwise have it executed again.
+func TestTerminalOutcomeWrappedInTransportIsNotRetried(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		inner error
+	}{
+		{name: "exit error", inner: &invoke.ExitError{Code: 1}},
+		{name: "closed", inner: fmt.Errorf("x: %w", invoke.ErrClosed)},
+		{name: "not found", inner: fmt.Errorf("x: %w", invoke.ErrNotFound)},
+		{name: "unsupported", inner: fmt.Errorf("x: %w", invoke.ErrNotSupported)},
+		{name: "invalid workdir", inner: fmt.Errorf("x: %w", invoke.ErrInvalidWorkdir)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			outcomes := make([]scriptOutcome, 3)
+			for i := range outcomes {
+				outcomes[i] = scriptOutcome{err: &invoke.TransportError{Op: "wait", Err: tt.inner}}
+			}
+
+			env := &scriptEnv{outcome: outcomes}
+			exec := invoke.NewExecutor(env, invoke.WithRetry(3, nil))
+
+			_, err := exec.Run(t.Context(), invoke.New("deploy", "--production"), invoke.IO{})
+			require.Error(t, err)
+
+			assert.Equal(t, 1, env.startCount(),
+				"a command whose outcome was already decided was run again under retry")
+		})
+	}
+}
+
+// TestTransferCarryingATerminalOutcomeIsNotRetried covers the other path
+// through the same classifier: transfers retry under their own loop.
+func TestTransferCarryingATerminalOutcomeIsNotRetried(t *testing.T) {
+	t.Parallel()
+
+	env := &transferEnv{
+		failFirst: 2,
+		err:       &invoke.TransportError{Op: "upload", Err: fmt.Errorf("x: %w", invoke.ErrNotFound)},
+	}
+	exec := invoke.NewExecutor(env, invoke.WithRetry(3, nil))
+
+	require.Error(t, exec.Upload(t.Context(), "src", "dst"))
+
+	assert.Equal(t, 1, env.uploads, "a transfer whose failure was already decided was attempted again")
+}
+
 func TestRetrySucceedsAfterTransientFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Wave 0 (security hotfix), PR 3 of 3 — the last one before `v0.3.1`. Independent of #2 and #3.

## The bug

Retry asks one question: *might the command not have run?* Only a transport failure answers yes, so only that family is retried. But `TransportError` unwraps, so one wrapping a terminal outcome belongs to **both** families at once:

```go
&TransportError{Op: "wait", Err: &ExitError{Code: 1}}
// errors.As(err, **ExitError)      -> true   (every contract assertion passes)
// errors.As(err, **TransportError) -> true   (and the classifier retries it)
```

A provider reporting a command's own verdict in that shape had the command run again. Reproduced before the fix, with `WithRetry(3, …)`:

```
Executor Start count for a command that RAN and exited 1: 3
>> side-effectful command re-run 3 times
```

That is the legacy ssh `ExitMissingError` disaster — an arbitrary command executed a second time on the strength of the first one's result — reachable again, and **invisible to the contract suite**: every assertion about the inner error still holds, so no contract can currently tell an honest classification from a laundered one.

## The fix

The classifier now requires the transport reading to be the *only* one. An error carrying an exit status — or a closed environment, missing executable, unusable working directory, unsupported feature — is terminal whatever else it also says.

The rule is documented on `TransportError` itself, where a provider author looks: it is not a wrapper for a verdict.

### Why cancellation is deliberately excluded

A provider's own per-attempt deadline produces a context error inside a *genuine* transport failure, and reading that as terminal would strand a retry the caller wanted. The caller's own cancellation needs no help here: `backoffWait` returns the context's error before the next attempt starts, so the command is never re-executed regardless. Including it would buy no safety and cost real false negatives.

### Why this belongs in the policy layer

I checked: no provider in this repository classifies this way, so **nothing here changes behaviour today**. The point is that the property no longer depends on every provider choosing to be honest — including third-party `Environment` implementations, which no contract in `invoketest` can reach. This is the "safe by construction" half. The matching *contract* (asserting providers don't launder) is Wave 2, and is what would catch an in-repo regression.

## Verification

- All six new subcases **fail against the previous behaviour**, each reporting the command was run again; covers both the `Run` path and the transfer path, which retries under its own loop.
- Existing retry tests unchanged and passing — an ordinary transport failure still retries, so this is not over-refusal.
- The original repro now starts the command **once**, and the provider's error is still returned as-is rather than double-wrapped.
- `just check` green (lint 0 issues both modules, race, Windows cross-build, tidy); OpenSSH lane green; live-daemon Docker lane green.