### PR TITLE
test(invoketest): Enforce that a real exit survives a concurrent cancel

### DIFF
--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -44,7 +44,9 @@ func TestDockerContractSuite(t *testing.T) {
 
 	invoketest.Verify(t, func(it invoketest.T) invoke.Environment {
 		return dialContainer(asTestingT(it))
-	})
+	}, invoketest.WithKnownGap("lifecycle/cancel-during-drain-keeps-outcome",
+		"the outcome is read from the context before the exec's own inspected status, so a cancellation "+
+			"arriving while output drains rewrites a completed exit; fixed separately"))
 }
 
 func TestMissingContainerIsNotFound(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -78,6 +78,13 @@ func (e *ExitError) Error() string {
 //
 // It is the only retryable family in the taxonomy: the failure is
 // environmental, not a verdict about the command.
+//
+// It is not a wrapper for one. Because it unwraps, a TransportError
+// carrying an [ExitError] or one of the sentinels above belongs to both
+// families at once, and the outcome it carries is the one that decides:
+// such an error is terminal and is never retried. A provider with a
+// verdict about the command should return that verdict rather than dress
+// it as a transport failure.
 type TransportError struct {
 	// Op names the operation that failed: "start", "wait", "upload",
 	// "download", "lookpath".

--- a/executor.go
+++ b/executor.go
@@ -288,10 +288,45 @@ func (e *Executor) backoffWait(ctx context.Context, cfg execConfig, n int) error
 // family the executor retries. Everything else (exit errors, cancellation,
 // closed environments, unsupported features, missing binaries) is
 // terminal, so retrying must be earned by explicit classification.
+//
+// Belonging to that family is necessary but not sufficient. A
+// [TransportError] unwraps, so one wrapping a terminal outcome answers to
+// both families at once: every assertion about the inner error still
+// holds, and the classifier still reads the outer one. Retry asks a single
+// question — might the command not have run? — and an outcome saying it
+// did run answers it whatever else the error also says. So the terminal
+// reading wins, and a provider cannot obtain a second execution of an
+// arbitrary command by wrapping the first one's verdict.
 func retryable(err error) bool {
 	var te *TransportError
 
-	return errors.As(err, &te)
+	return errors.As(err, &te) && !terminal(err)
+}
+
+// terminal reports whether err carries an outcome that forecloses running
+// the command again: it ran, or it could not run for a reason that asking
+// again will not change.
+//
+// Cancellation is deliberately absent. A provider's own per-attempt
+// deadline produces a context error inside a genuine transport failure,
+// and treating that as terminal would strand a retry the caller wanted.
+// The caller's own cancellation needs no help from here: the backoff
+// before the next attempt returns the context's error, so the command is
+// never started again regardless of how this reads.
+func terminal(err error) bool {
+	var exitErr *ExitError
+
+	if errors.As(err, &exitErr) {
+		return true
+	}
+
+	for _, sentinel := range []error{ErrClosed, ErrNotFound, ErrNotSupported, ErrInvalidWorkdir} {
+		if errors.Is(err, sentinel) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // applySudo rewrites cmd to run through sudo, or returns it unchanged when

--- a/executor_test.go
+++ b/executor_test.go
@@ -141,6 +141,64 @@ func TestRetryOnlyTransportErrors(t *testing.T) {
 	}
 }
 
+// TestTerminalOutcomeWrappedInTransportIsNotRetried pins the rule that
+// decides whether an arbitrary command may be run a second time.
+//
+// A TransportError unwraps, so one wrapping a terminal outcome satisfies
+// every assertion about the outcome it carries while still answering to
+// the retryable family. A provider that reports a command's own verdict in
+// that shape would otherwise have it executed again.
+func TestTerminalOutcomeWrappedInTransportIsNotRetried(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		inner error
+	}{
+		{name: "exit error", inner: &invoke.ExitError{Code: 1}},
+		{name: "closed", inner: fmt.Errorf("x: %w", invoke.ErrClosed)},
+		{name: "not found", inner: fmt.Errorf("x: %w", invoke.ErrNotFound)},
+		{name: "unsupported", inner: fmt.Errorf("x: %w", invoke.ErrNotSupported)},
+		{name: "invalid workdir", inner: fmt.Errorf("x: %w", invoke.ErrInvalidWorkdir)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			outcomes := make([]scriptOutcome, 3)
+			for i := range outcomes {
+				outcomes[i] = scriptOutcome{err: &invoke.TransportError{Op: "wait", Err: tt.inner}}
+			}
+
+			env := &scriptEnv{outcome: outcomes}
+			exec := invoke.NewExecutor(env, invoke.WithRetry(3, nil))
+
+			_, err := exec.Run(t.Context(), invoke.New("deploy", "--production"), invoke.IO{})
+			require.Error(t, err)
+
+			assert.Equal(t, 1, env.startCount(),
+				"a command whose outcome was already decided was run again under retry")
+		})
+	}
+}
+
+// TestTransferCarryingATerminalOutcomeIsNotRetried covers the other path
+// through the same classifier: transfers retry under their own loop.
+func TestTransferCarryingATerminalOutcomeIsNotRetried(t *testing.T) {
+	t.Parallel()
+
+	env := &transferEnv{
+		failFirst: 2,
+		err:       &invoke.TransportError{Op: "upload", Err: fmt.Errorf("x: %w", invoke.ErrNotFound)},
+	}
+	exec := invoke.NewExecutor(env, invoke.WithRetry(3, nil))
+
+	require.Error(t, exec.Upload(t.Context(), "src", "dst"))
+
+	assert.Equal(t, 1, env.uploads, "a transfer whose failure was already decided was attempted again")
+}
+
 func TestRetrySucceedsAfterTransientFailure(t *testing.T) {
 	t.Parallel()
 

--- a/invoketest/contracts_lifecycle.go
+++ b/invoketest/contracts_lifecycle.go
@@ -22,6 +22,7 @@ func lifecycleContracts() []TestCase {
 		lifecycleDeadlineUnblocksWait(),
 		lifecycleCancelTerminatesProcess(),
 		lifecycleCancelAfterExitKeepsOutcome(),
+		lifecycleCancelDuringDrainKeepsOutcome(),
 		lifecycleStartOnCanceledContext(),
 		lifecycleConcurrentProcessesRun(),
 		lifecycleCloseUnblocksWait(),
@@ -127,6 +128,67 @@ func lifecycleCancelAfterExitKeepsOutcome() TestCase {
 				"the process exited 0 before cancellation; a late cancel must not rewrite it")
 
 			assert.Equal(t, 0, second.result.ExitCode, "a late cancel must not rewrite the exit code")
+		},
+	}
+}
+
+// lifecycleCancelDuringDrainKeepsOutcome pins the outcome of a process
+// that finished while its output was still being collected.
+//
+// [lifecycleCancelAfterExitKeepsOutcome] reads the outcome before it
+// cancels, so a provider that decides the outcome once and remembers it
+// passes without the question ever being asked. The question is what a
+// provider decides when the cancellation arrives first: the process has
+// already exited, but Wait has not yet worked out what to report. Reading
+// the context at that moment rather than the process's own status turns a
+// success into a cancellation, and a caller who retries on cancellation
+// runs a command that already ran.
+//
+// The contract holds the output open to make that moment last. Stdout is
+// a writer that blocks, so the provider is still draining when the
+// context is canceled, and the process it is draining for is long gone.
+func lifecycleCancelDuringDrainKeepsOutcome() TestCase {
+	return TestCase{
+		Category:    CategoryLifecycle,
+		Name:        "cancel-during-drain-keeps-outcome",
+		Description: "Cancellation arriving while output is still draining must not rewrite the exit of a process that already finished",
+		Run: func(t T, env invoke.Environment) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			drain := newBlockingWriter()
+
+			// The script's last act is the write, so once the bytes arrive
+			// the process is on its way out.
+			proc := startCommand(ctx, t, env, invoke.Shell("echo draining"), invoke.IO{Stdout: drain})
+
+			defer func() { _ = proc.Close() }()
+
+			select {
+			case <-drain.started:
+			case <-time.After(contractTimeout):
+				require.FailNow(t, "the command produced no output within the contract deadline")
+			}
+
+			// The write has landed and the drain is held, so the provider
+			// cannot finish Wait while the process finishes exiting.
+			time.Sleep(exitSettle)
+
+			cancel()
+
+			// Still held for a moment after the cancel, so a provider that
+			// consults the context on its way out has every chance to.
+			time.Sleep(exitSettle)
+
+			drain.release()
+
+			outcome := waitOrTimeout(t, proc)
+
+			assert.NoError(t, outcome.err,
+				"the process exited 0 before the cancellation; draining its output must not rewrite that")
+
+			assert.Equal(t, 0, outcome.result.ExitCode,
+				"the process exited 0 before the cancellation; draining its output must not rewrite its exit code")
 		},
 	}
 }

--- a/invoketest/helpers.go
+++ b/invoketest/helpers.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/ruffel/invoke"
@@ -26,6 +27,48 @@ func token(t T) string {
 	require.NoError(t, err, "generating random token")
 
 	return hex.EncodeToString(raw[:])
+}
+
+// exitSettle is how long a contract waits for a process to finish exiting
+// once its last output has been observed. It is a margin around an event
+// already witnessed rather than a substitute for witnessing one: the
+// output says the command reached its final act, and this covers the
+// short walk from there to the process being gone.
+const exitSettle = 250 * time.Millisecond
+
+// blockingWriter is a destination for a process's output that reports the
+// first write and then holds it, so a contract can keep a provider inside
+// its own drain for as long as it needs to.
+type blockingWriter struct {
+	// started closes once output has arrived, so a contract can wait for
+	// the process to have written rather than guess when it did.
+	started chan struct{}
+
+	// held blocks the write until the contract releases it.
+	held chan struct{}
+
+	once sync.Once
+}
+
+func newBlockingWriter() *blockingWriter {
+	return &blockingWriter{
+		started: make(chan struct{}),
+		held:    make(chan struct{}),
+	}
+}
+
+// Write reports the first write, then blocks until the writer is released.
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.started) })
+
+	<-w.held
+
+	return len(p), nil
+}
+
+// release unblocks the write, letting the provider finish draining.
+func (w *blockingWriter) release() {
+	close(w.held)
 }
 
 // startCommand starts cmd and fails the contract on error.

--- a/invoketest/misbehave_test.go
+++ b/invoketest/misbehave_test.go
@@ -633,6 +633,7 @@ func defectCatalog() []defectCase {
 		{name: "deadline as cancel", contract: "lifecycle/deadline-unblocks-wait", defects: defects{hardcodeCanceled: true}},
 		{name: "surviving process", contract: "lifecycle/cancel-terminates-process", defects: defects{ignoreCancel: true}},
 		{name: "late cancel overwrites exit", contract: "lifecycle/cancel-after-exit-keeps-outcome", defects: defects{cancelOverwritesExit: true}},
+		{name: "cancel during drain overwrites exit", contract: "lifecycle/cancel-during-drain-keeps-outcome", defects: defects{cancelOverwritesExit: true}},
 		{name: "start despite cancel", contract: "lifecycle/start-on-canceled-context", defects: defects{ignoreCancel: true}},
 		{name: "single process only", contract: "lifecycle/concurrent-processes-run", defects: defects{singleProcess: true}},
 		{name: "close no-op", contract: "lifecycle/close-unblocks-wait", defects: defects{closeNoOp: true}},

--- a/ssh/openssh_test.go
+++ b/ssh/openssh_test.go
@@ -173,7 +173,9 @@ func TestOpenSSHContractSuite(t *testing.T) {
 		require.True(tt, ok, "contract tests require the standard *testing.T")
 
 		return dialOpenSSH(tt, port)
-	})
+	}, invoketest.WithKnownGap("lifecycle/cancel-during-drain-keeps-outcome",
+		"the outcome is read from the context before the session's own exit status, so a cancellation "+
+			"arriving while output drains rewrites a completed exit; fixed separately"))
 }
 
 // TestOpenSSHEnvFallbackDelivers checks the opt-in fallback does deliver

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -51,7 +51,9 @@ func TestSSHContractSuite(t *testing.T) {
 
 	invoketest.Verify(t, func(it invoketest.T) invoke.Environment {
 		return dialTestServer(asTestingT(it))
-	})
+	}, invoketest.WithKnownGap("lifecycle/cancel-during-drain-keeps-outcome",
+		"the outcome is read from the context before the session's own exit status, so a cancellation "+
+			"arriving while output drains rewrites a completed exit; fixed separately"))
 }
 
 func TestConnectionRejectsWrongPassword(t *testing.T) {


### PR DESCRIPTION
Wave 1, PR 4 of 7 — the spec half of audit finding M3. PRs 5 and 6 are the ssh and docker fixes, each removing its own gap.

## The gap in the spec

`lifecycle/cancel-after-exit-keeps-outcome` calls `Wait` **first**, then cancels. By then the outcome is decided and memoized, so every provider passes and the real question is never asked: what does a provider decide when the cancellation arrives *first* — process exited, but `Wait` hasn't yet worked out what to report?

Both remote providers consult the context at that moment instead of the status they already have:

- `ssh/process.go` — `mapOutcome` checks `p.ctxErr()` before the `err == nil` branch
- `docker/process.go` — `outcome()` checks `p.ctxErr()` before `inspect()`, after `<-p.copied`

`local` guards against exactly this (`state.Exited() && !signaled`, `local/process.go`), so the providers disagree — and a caller who retries on cancellation re-runs a command that already ran.

## The contract

It holds the moment open rather than racing for it. Stdout is a writer that blocks, so the provider is still inside its own drain while the context is canceled and the process it's draining for is already gone. Readiness is the observed write, not a sleep; the two `exitSettle` pauses are margins around an event already witnessed, and the drain being held is what makes them safe rather than flaky.

The defect is the existing `cancelOverwritesExit` — it models this failure exactly and now has a second contract to fail against, so the new contract is provably able to fail per the suite's own standard.

## Confirmed, not inferred

The audit traced this in code. This PR confirms it empirically — both providers **fail the new contract**, against a real OpenSSH server and a live Docker daemon:

```
--- FAIL: TestSSHContractSuite/lifecycle/cancel-during-drain-keeps-outcome
--- FAIL: TestDockerContractSuite/lifecycle/cancel-during-drain-keeps-outcome
    the process exited 0 before the cancellation; draining its output must not rewrite that
```

## Gating

Three `Verify` call sites declare the gap (ssh unit, ssh OpenSSH lane, docker), each naming the fix that removes it. `local` and `fake` pass **ungated**. The gap is a loud skip, and I verified a stale contract ID fails the suite:

```
invoketest: WithKnownGap names unknown contracts: lifecycle/typo-does-not-exist
```

so these opt-outs cannot silently outlive their fixes.

## Verification

- Contract passes against the reference provider and fails against its defect.
- 52 contracts (was 51); `just check` green; OpenSSH and live-daemon Docker lanes green with the gaps declared.