### PR TITLE
fix(ssh): Attribute cancellation only when it ended the command

### DIFF
--- a/ssh/exec_test.go
+++ b/ssh/exec_test.go
@@ -2,10 +2,12 @@ package ssh_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ruffel/invoke"
 	"github.com/ruffel/invoke/ssh"
@@ -199,3 +201,52 @@ func TestRelativePathResolvesAgainstWorkdir(t *testing.T) {
 
 	assert.Equal(t, "ran", strings.TrimSpace(out))
 }
+
+// TestNonZeroExitSurvivesConcurrentCancel covers the half of cancellation
+// attribution the contract cannot reach: the contract pins a clean exit,
+// and a status the server reported is authoritative whatever it says.
+func TestNonZeroExitSurvivesConcurrentCancel(t *testing.T) {
+	t.Parallel()
+
+	env := dialServer(t, startTestServer(t))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	release := make(chan struct{})
+	written := make(chan struct{})
+
+	stdout := writerFunc(func(p []byte) (int, error) {
+		close(written)
+		<-release
+
+		return len(p), nil
+	})
+
+	proc, err := env.Start(ctx, invoke.Shell("echo out; exit 9"), invoke.IO{Stdout: stdout})
+	require.NoError(t, err)
+
+	<-written
+
+	// The command has produced its output and is exiting; cancel while the
+	// provider is still held inside the drain.
+	time.Sleep(250 * time.Millisecond)
+	cancel()
+	time.Sleep(250 * time.Millisecond)
+	close(release)
+
+	result, waitErr := proc.Wait()
+
+	var exitErr *invoke.ExitError
+
+	require.ErrorAs(t, waitErr, &exitErr,
+		"the server reported exit 9 before the cancellation; that status must survive it")
+
+	assert.Equal(t, 9, exitErr.Code, "the reported exit status was rewritten")
+	assert.Equal(t, 9, result.ExitCode, "the reported exit code was rewritten")
+}
+
+// writerFunc adapts a function to io.Writer.
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }

--- a/ssh/openssh_test.go
+++ b/ssh/openssh_test.go
@@ -173,9 +173,7 @@ func TestOpenSSHContractSuite(t *testing.T) {
 		require.True(tt, ok, "contract tests require the standard *testing.T")
 
 		return dialOpenSSH(tt, port)
-	}, invoketest.WithKnownGap("lifecycle/cancel-during-drain-keeps-outcome",
-		"the outcome is read from the context before the session's own exit status, so a cancellation "+
-			"arriving while output drains rewrites a completed exit; fixed separately"))
+	})
 }
 
 // TestOpenSSHEnvFallbackDelivers checks the opt-in fallback does deliver

--- a/ssh/process.go
+++ b/ssh/process.go
@@ -325,7 +325,33 @@ func (p *process) monitorContext(ctx context.Context) {
 // mapOutcome classifies the raw session-wait error into the package
 // taxonomy, attributing a caller-initiated kill to Close or cancellation
 // rather than reporting it as a command exit.
+//
+// A status the server reported settles the outcome before the attribution
+// flags are read. Cancellation and Close are things this side did, and
+// neither unruns a command the server already accounted for: the status
+// arrived, so the command finished, whatever this side went on to want.
+// Reading the flags first turned a completed command into a cancellation
+// whenever the two raced — and a caller who retries on cancellation would
+// then run it again.
+//
+// What remains after that is a death this side could have caused: a kill
+// signal, or no status at all. Those are the flags' to claim.
 func (p *process) mapOutcome(err error, duration time.Duration) (invoke.Result, error) {
+	sig, signaled := waitSignal(err)
+
+	if !signaled {
+		if res, outcome, reported := reportedExit(err, duration); reported {
+			return res, outcome
+		}
+	}
+
+	// A signal this side never sends belongs to the command: the session
+	// is killed with SIGKILL and nothing else, so anything else is the
+	// remote end's own doing and outlives any local bookkeeping.
+	if signaled && sig != invoke.SIGKILL {
+		return invoke.Result{ExitCode: -1, Duration: duration}, &invoke.ExitError{Code: -1, Signal: sig}
+	}
+
 	if p.closedByUser.Load() {
 		return invoke.Result{ExitCode: -1, Duration: duration},
 			fmt.Errorf("ssh: wait: process terminated by Close: %w", invoke.ErrClosed)
@@ -335,20 +361,9 @@ func (p *process) mapOutcome(err error, duration time.Duration) (invoke.Result, 
 		return invoke.Result{ExitCode: -1, Duration: duration}, fmt.Errorf("ssh: wait: %w", ctxErr)
 	}
 
-	if err == nil {
-		return invoke.Result{ExitCode: 0, Duration: duration}, nil
-	}
-
-	var exitErr *ssh.ExitError
-	if errors.As(err, &exitErr) {
-		if sig := exitErr.Signal(); sig != "" {
-			return invoke.Result{ExitCode: -1, Duration: duration},
-				&invoke.ExitError{Code: -1, Signal: invoke.Signal(sig)}
-		}
-
-		code := exitErr.ExitStatus()
-
-		return invoke.Result{ExitCode: code, Duration: duration}, &invoke.ExitError{Code: code}
+	// A kill nobody here asked for is still the command's own death.
+	if signaled {
+		return invoke.Result{ExitCode: -1, Duration: duration}, &invoke.ExitError{Code: -1, Signal: sig}
 	}
 
 	// ExitMissingError: the command ran but no status came back, which is
@@ -368,6 +383,39 @@ func (p *process) mapOutcome(err error, duration time.Duration) (invoke.Result, 
 	}
 
 	return invoke.Result{ExitCode: -1, Duration: duration}, &invoke.TransportError{Op: "wait", Err: err}
+}
+
+// waitSignal reports the signal a session-wait error attributes the
+// command's death to, and whether it named one at all.
+func waitSignal(err error) (invoke.Signal, bool) {
+	var exitErr *ssh.ExitError
+	if !errors.As(err, &exitErr) {
+		return "", false
+	}
+
+	sig := exitErr.Signal()
+	if sig == "" {
+		return "", false
+	}
+
+	return invoke.Signal(sig), true
+}
+
+// reportedExit returns the outcome for a session-wait error carrying an
+// exit status the server sent, and whether it carried one.
+func reportedExit(err error, duration time.Duration) (invoke.Result, error, bool) { //nolint:revive // The flag distinguishes "no status" from a zero one.
+	if err == nil {
+		return invoke.Result{ExitCode: 0, Duration: duration}, nil, true
+	}
+
+	var exitErr *ssh.ExitError
+	if !errors.As(err, &exitErr) {
+		return invoke.Result{}, nil, false
+	}
+
+	code := exitErr.ExitStatus()
+
+	return invoke.Result{ExitCode: code, Duration: duration}, &invoke.ExitError{Code: code}, true
 }
 
 // runRaw runs a raw command line on a fresh session and returns its stdout

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -51,9 +51,7 @@ func TestSSHContractSuite(t *testing.T) {
 
 	invoketest.Verify(t, func(it invoketest.T) invoke.Environment {
 		return dialTestServer(asTestingT(it))
-	}, invoketest.WithKnownGap("lifecycle/cancel-during-drain-keeps-outcome",
-		"the outcome is read from the context before the session's own exit status, so a cancellation "+
-			"arriving while output drains rewrites a completed exit; fixed separately"))
+	})
 }
 
 func TestConnectionRejectsWrongPassword(t *testing.T) {


### PR DESCRIPTION
Wave 1, PR 5 of 7 — the ssh half of audit finding M3. Removes the known gap #5 added. PR 6 does the same for docker; the two are independent.

## The bug

`mapOutcome` read the context *before* the status the server sent:

```go
if ctxErr := p.ctxErr(); ctxErr != nil { return ..., ctxErr }   // ← first
if err == nil { return exit 0 }                                  // ← never reached
```

So a cancellation arriving while output still drained rewrote a command that had already finished — reported as a cancellation, and **a caller who retries on cancellation would run it a second time**.

## The fix

A reported status now settles the outcome before the attribution flags are read. The reasoning, which is the same evidence `local` has always used:

- Cancellation and Close are things *this side* did. Neither unruns a command the server already accounted for — the status arrived, so it finished, whatever this side went on to want.
- What remains is a death this side *could* have caused: a kill signal, or no status at all. Those stay the flags' to claim.
- A signal other than the `SIGKILL` this side sends is the command's own death, and outlives the bookkeeping too (mirroring local's `killedByUs` evidence check).

This deliberately goes slightly beyond the contract: the contract pins a clean exit, but a **reported status is authoritative whatever it says**, so a non-zero exit is covered by the same rule and by its own unit test.

## Verification

- The contract now passes **ungated** on both the embedded server and, importantly, the **real OpenSSH lane** — the gap is removed from both call sites.
- I confirmed the fix is load-bearing rather than the gap removal papering over it: disabling the new branch makes `lifecycle/cancel-during-drain-keeps-outcome` fail again.
- `TestNonZeroExitSurvivesConcurrentCancel` covers the non-zero case the contract cannot reach; it also fails without the fix.
- Every other cancellation contract still passes (`cancel-unblocks-wait`, `cancel-terminates-process`, `cancel-after-exit-keeps-outcome`, `start-on-canceled-context`) — attribution still works where cancellation genuinely did end the command.
- `just check` green; `-tags openssh` lane green.