### PR TITLE
fix(ssh): Treat every wait-time failure without a status as terminal

### DIFF
--- a/ssh/env_internal_test.go
+++ b/ssh/env_internal_test.go
@@ -1,11 +1,16 @@
 package ssh
 
 import (
+	"errors"
+	"io"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/ruffel/invoke"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 )
 
 // TestDefaultEnvRouteKeepsValuesOffTheCommandLine pins the property the
@@ -69,6 +74,53 @@ func TestEnvValuesAreQuotedOnEitherRoute(t *testing.T) {
 			// literal, so the injected text survives as data.
 			assert.Contains(t, rendered, `'\''`,
 				"an embedded quote must be escaped, not passed through")
+		})
+	}
+}
+
+// TestWaitFailureWithoutAStatusIsTerminal pins the classification of a
+// command interrupted before it reported a status.
+//
+// The end-to-end test cannot reach this: severing the connection in the
+// unit lane reliably produces ExitMissingError, which was terminal
+// already. The shapes below are the ones the same outage produces when a
+// different part of the session notices it first, and which one a caller
+// gets is not something they chose. All of them must classify alike, or
+// the executor retries an arbitrary command on a coin flip.
+func TestWaitFailureWithoutAStatusIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "missing exit status", err: &ssh.ExitMissingError{}},
+		{name: "stream ended", err: io.EOF},
+		{name: "channel closed", err: errors.New("ssh: channel closed")},
+		{name: "connection reset", err: &net.OpError{Op: "read", Err: errors.New("connection reset by peer")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			proc := &process{ctxErr: func() error { return nil }}
+
+			result, err := proc.mapOutcome(tt.err, time.Second)
+			require.Error(t, err, "a wait that learned no status reported success")
+
+			var transportErr *invoke.TransportError
+
+			assert.NotErrorAs(t, err, &transportErr,
+				"a command interrupted before it reported a status must not be retryable: "+
+					"it may already have taken effect")
+
+			assert.ErrorIs(t, err, tt.err, "the underlying failure must stay reachable")
+
+			assert.ErrorContains(t, err, "may or may not",
+				"the error does not report the outcome as unknown")
+
+			assert.Equal(t, -1, result.ExitCode, "an unknown outcome must not carry a real-looking exit code")
 		})
 	}
 }

--- a/ssh/process.go
+++ b/ssh/process.go
@@ -366,23 +366,25 @@ func (p *process) mapOutcome(err error, duration time.Duration) (invoke.Result, 
 		return invoke.Result{ExitCode: -1, Duration: duration}, &invoke.ExitError{Code: -1, Signal: sig}
 	}
 
-	// ExitMissingError: the command ran but no status came back, which is
-	// what a connection dying under a running command looks like.
+	// Every remaining failure is the same fact in a different shape: the
+	// command was started and no status came back for it.
 	//
-	// This is deliberately terminal rather than a TransportError. The
-	// command may have already taken effect, and nothing here can tell
+	// ExitMissingError is the shape the library names, but which one an
+	// outage produces is not something the caller chose — the same dying
+	// connection surfaces as a missing status, a broken channel, or a
+	// read error, depending on which part of the session noticed first.
+	// Classifying only the named one as terminal made retryability a coin
+	// flip on identical outages.
+	//
+	// So none of them is a TransportError, which is the retryable family.
+	// The command may already have taken effect, and nothing here can tell
 	// whether it did, so retrying it would be at-least-once execution of
 	// an arbitrary command. File transfers classify the same outage as
 	// retryable because their delivery is atomic; commands have no such
 	// guarantee, and the caller must decide.
-	var missing *ssh.ExitMissingError
-	if errors.As(err, &missing) {
-		return invoke.Result{ExitCode: -1, Duration: duration},
-			fmt.Errorf("ssh: wait: the connection ended before the remote command reported a status, "+
-				"so it may or may not have run to completion: %w", err)
-	}
-
-	return invoke.Result{ExitCode: -1, Duration: duration}, &invoke.TransportError{Op: "wait", Err: err}
+	return invoke.Result{ExitCode: -1, Duration: duration},
+		fmt.Errorf("ssh: wait: the connection ended before the remote command reported a status, "+
+			"so it may or may not have run to completion: %w", err)
 }
 
 // waitSignal reports the signal a session-wait error attributes the

--- a/ssh/transport_test.go
+++ b/ssh/transport_test.go
@@ -20,30 +20,42 @@ import (
 // tell whether it did. Classifying it retryable would let the executor
 // run an arbitrary command a second time — the asymmetry with transfers,
 // which are retryable precisely because their delivery is atomic.
+//
+// One outage surfaces several ways depending on which part of the session
+// notices it first: a missing exit status, a broken channel, a read error
+// on the connection. The caller did not choose which, so all of them must
+// classify alike or retryability becomes a coin flip on identical
+// outages. This repeats to cover whichever the timing produces.
 func TestSeveredConnectionDuringCommandIsTerminal(t *testing.T) {
 	t.Parallel()
 
-	srv := startTestServer(t)
-	env := dialServer(t, srv)
+	const attempts = 8
 
-	proc, err := env.Start(t.Context(), invoke.New("sleep", "30"), invoke.IO{})
-	require.NoError(t, err)
+	for i := range attempts {
+		srv := startTestServer(t)
+		env := dialServer(t, srv)
 
-	// Let the command settle, then drop the connection under it.
-	time.Sleep(50 * time.Millisecond)
-	srv.sever()
+		proc, err := env.Start(t.Context(), invoke.New("sleep", "30"), invoke.IO{})
+		require.NoErrorf(t, err, "attempt %d", i)
 
-	_, waitErr := proc.Wait()
-	require.Error(t, waitErr, "Wait after the connection died reported success")
+		// Let the command settle, then drop the connection under it.
+		time.Sleep(50 * time.Millisecond)
+		srv.sever()
 
-	var transportErr *invoke.TransportError
+		_, waitErr := proc.Wait()
+		require.Errorf(t, waitErr, "attempt %d: Wait after the connection died reported success", i)
 
-	assert.NotErrorAs(t, waitErr, &transportErr, "Wait after the connection died must be a terminal error: "+
-		"an interrupted command must not be retried automatically")
+		var transportErr *invoke.TransportError
 
-	// The reason must be legible: "no exit status" alone does not tell a
-	// caller their command may have half-run.
-	assert.ErrorContains(t, waitErr, "may or may not", "the error does not report the outcome as unknown")
+		assert.NotErrorAsf(t, waitErr, &transportErr,
+			"attempt %d: Wait after the connection died must be a terminal error: "+
+				"an interrupted command must not be retried automatically", i)
+
+		// The reason must be legible: "no exit status" alone does not tell
+		// a caller their command may have half-run.
+		assert.ErrorContainsf(t, waitErr, "may or may not",
+			"attempt %d: the error does not report the outcome as unknown", i)
+	}
 }
 
 // TestSeveredConnectionDuringTransferIsTransportError checks the same for


### PR DESCRIPTION
Wave 1, PR 7 of 7. Independent of the others.

## The bug

The README and `doc.go` promise that a connection dying under a running command is **terminal** — the command may already have taken effect, and nothing on this side can tell. `mapOutcome` honoured that for the one shape the library names, and then undid it on the next line:

```go
var missing *ssh.ExitMissingError
if errors.As(err, &missing) { return terminal }          // ← honoured here
return ..., &invoke.TransportError{Op: "wait", Err: err} // ← retryable for everything else
```

Which shape an outage produces is **not something the caller chose** — the same dying connection surfaces as a missing exit status, a broken channel, or a read error, depending on which part of the session noticed first. So an outage that surfaced one way would re-run an arbitrary command under `WithRetry`, and the same outage surfacing another way would not. Retryability was a coin flip on identical events.

## The fix

All wait-time failures without a status now classify alike, in the same terms: the command was started, no status came back, the caller decides. Start-time failures are untouched and stay retryable — at that point the command genuinely has not run.

## Why the existing test did not catch it, and what does

This is the part worth reviewing. `TestSeveredConnectionDuringCommandIsTerminal` **passes with or without this change** — I verified it, 3/3. Severing the connection in the unit lane reliably produces `ExitMissingError`, the shape that was already terminal, so the test never reaches the line it needs to.

So it would have been a can't-fail test for this fix. Instead:

- **`TestWaitFailureWithoutAStatusIsTerminal`** (internal) pins the rule directly against the shapes the same outage produces when a different part of the session notices first — missing status, `io.EOF`, channel closed, `net.OpError`. **Three of its four subcases fail without the fix** (the `ExitMissingError` one correctly still passes, since it was already terminal). This is the load-bearing test.
- The end-to-end test now **repeats**, exactly as its transfer counterpart already does for the same reason, so a future change in which shape appears is caught rather than assumed. It adds no coverage today, and I would rather say that than imply otherwise.

## Verification

- `just check` green; `-tags openssh` lane green against a real server.
- Every other ssh contract and transport test unchanged and passing — transfers still classify the same outage as **retryable**, which is correct and is the asymmetry the taxonomy exists to express: their delivery is atomic, commands' is not.

This closes the last of the Wave 1 items I had on the ssh provider.