### PR TITLE
fix(docker): Refuse to start a process into a closing environment

### DIFF
--- a/docker/environment.go
+++ b/docker/environment.go
@@ -239,11 +239,27 @@ func (e *Environment) checkOpen(op string) error {
 	return nil
 }
 
-func (e *Environment) track(p *process) {
+// track registers a running process so Close can terminate it, unless the
+// environment has closed in the meantime.
+//
+// Start checks the closed flag once at entry and then spends several
+// daemon round-trips creating the exec. A Close landing in that window has
+// already snapshotted the active set and moved on, so a process added
+// afterwards would run in a closed environment with nothing left to stop
+// it. Re-checking here under the same lock closes that gap: a process is
+// either registered before Close snapshots, and terminated with the rest,
+// or refused, and torn down by its caller.
+func (e *Environment) track(p *process) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	if e.closed {
+		return fmt.Errorf("docker: start: %w", invoke.ErrClosed)
+	}
+
 	e.active[p] = struct{}{}
+
+	return nil
 }
 
 func (e *Environment) untrack(p *process) {

--- a/docker/process.go
+++ b/docker/process.go
@@ -90,7 +90,15 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 		done:    make(chan struct{}),
 	}
 
-	e.track(p)
+	if err := e.track(p); err != nil {
+		// The environment closed while the exec was being created; tear it
+		// down rather than leak it, detaching from ctx exactly as the other
+		// kill paths do.
+		//nolint:contextcheck // discard's kill detaches by design; see kill's comment.
+		p.discard()
+
+		return nil, err
+	}
 
 	go p.pumpStdin(stdio.Stdin)
 	go p.pumpOutput(stdio)
@@ -250,6 +258,23 @@ func (p *process) Close() error {
 	})
 
 	return nil
+}
+
+// discard tears down an exec that was created but never handed back,
+// because the environment closed before it could be tracked. The stdin
+// and output pumps have not started, so there is nothing to unblock;
+// killing the process and closing the stream is the whole of it.
+func (p *process) discard() {
+	if !p.tty {
+		_ = p.attach.CloseWrite()
+	}
+
+	// Best effort, exactly as Close's own kill is: a shell-less container
+	// cannot be signalled, and the exec then runs to its own end whether
+	// this is reached or not.
+	_ = p.kill(invoke.SIGKILL)
+
+	p.attach.Close()
 }
 
 // kill signals the command by the id its wrapper recorded.

--- a/docker/track_test.go
+++ b/docker/track_test.go
@@ -1,0 +1,45 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/ruffel/invoke"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTrackRefusesAProcessAfterClose pins the guard that keeps a process
+// from being registered into a closed environment.
+//
+// Start checks the closed flag at entry and then creates the exec over
+// several daemon round-trips. A Close in that window has already gathered
+// the processes it will terminate, so one added afterwards would run with
+// nothing left to stop it. track must refuse it instead, and leave the
+// active set untouched, so Start knows to tear the exec down.
+func TestTrackRefusesAProcessAfterClose(t *testing.T) {
+	t.Parallel()
+
+	env := &Environment{active: make(map[*process]struct{})}
+
+	p := &process{}
+
+	require.NoError(t, env.track(p), "an open environment must accept a process")
+
+	_, registered := env.active[p]
+	assert.True(t, registered, "an accepted process must be registered for termination")
+
+	// The environment closes while a second Start is between its own entry
+	// check and this point.
+	env.mu.Lock()
+	env.closed = true
+	env.mu.Unlock()
+
+	other := &process{}
+
+	err := env.track(other)
+	require.ErrorIs(t, err, invoke.ErrClosed, "track into a closed environment must refuse with ErrClosed")
+
+	_, leaked := env.active[other]
+	assert.False(t, leaked,
+		"a refused process must not be registered, or Close will already have passed it by")
+}


### PR DESCRIPTION
Wave 1, PR 8 of ~10 — audit finding M5 (Start/Close TOCTOU).

## The bug

`Start` checks `closed` once at entry, then creates the exec over several daemon round-trips (`preCheck`, `createExec`, `ContainerExecAttach`) before calling `track(p)`. `track` never re-checked the flag. So a `Close` landing in that window:

1. sets `closed`, snapshots the active set (without `p`), terminates that snapshot;
2. `Start` then registers `p` — a **running** process — into a closed environment, and hands it back with a **nil error**.

That violates the interface contract two ways: "after Close, every method fails with ErrClosed" and "processes still running are terminated." It's the legacy "TOCTOU on the closed flag" reintroduced.

## The fix

`track` re-checks `closed` under the same lock that guards the active set. A process is now either registered before Close gathers its own (and terminated with them), or refused with `ErrClosed`. A refused process leaves an exec that was created but never handed back, so `Start` tears it down via `discard()` — closing the stream and best-effort killing the exec, the same termination `Close` itself performs.

## On testing — the part worth reading

**`TestTrackRefusesAProcessAfterClose`** (internal, daemon-free, default lane) is the load-bearing proof: it pins that `track` into a closed environment refuses with `ErrClosed` and leaves the active set untouched. **It fails without the re-check.**

I also wrote a daemon-backed test that raced Start against Close and asserted the returned process didn't outlive the environment — and then **deleted it, because it could not fail.** Closing the environment closes the API client, which tears the attach stream and unblocks `Wait` *even for a leaked process*, so a survivor is indistinguishable from a terminated one through the handle. Rather than ship a test that passes against the buggy code (I verified it does), I removed it and rely on the deterministic unit test. Flagging this explicitly because a green integration test here would have been misleading.

## Scope — the same bug is in ssh and local

`ssh` and `local` have the **identical** unguarded `track`, registering after their own setup. Their setup is shorter so the window is narrower, but the class is shared. I scoped this PR to docker (the flagged, widest-window case; the `discard()` teardown is genuinely per-provider) rather than silently touch three providers in one change. **Recommend a follow-up** applying the same guard to ssh and local — or, better, a Wave 2 `concurrent-start-and-close` contract once I can make the race deterministic across providers (the client-close-unblocks-Wait problem above is why that needs thought).

## Verification

- `just check` green; full `-tags docker` lane green against a live daemon (contracts + parity + transfers), so `discard()` doesn't disturb normal operation and is race-clean.
- Unit test fails without the guard, passes with it.