### PR TITLE
fix(ssh, local): Refuse to start a process into a closing environment

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -124,11 +124,26 @@ func (e *Environment) checkOpen(op string) error {
 	return nil
 }
 
-func (e *Environment) track(p *process) {
+// track registers a running process so Close can terminate it, unless the
+// environment has closed in the meantime.
+//
+// Start checks the closed flag once at entry and then starts the process
+// and wires its streams. A Close landing in that window has already
+// gathered the processes it will terminate, so one added afterwards would
+// run with nothing left to stop it. Re-checking here under the same lock
+// closes that gap: a process is either registered before Close snapshots,
+// and terminated with the rest, or refused, and torn down by its caller.
+func (e *Environment) track(p *process) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	if e.closed {
+		return fmt.Errorf("local: start: %w", invoke.ErrClosed)
+	}
+
 	e.active[p] = struct{}{}
+
+	return nil
 }
 
 func (e *Environment) untrack(p *process) {

--- a/local/process.go
+++ b/local/process.go
@@ -128,7 +128,14 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 		}(stdio.Stdin, p.stdinW)
 	}
 
-	e.track(p)
+	if err := e.track(p); err != nil {
+		// The environment closed while the process was being started. Tear
+		// it down rather than leave it running past the environment that
+		// owns it; the process is fully started, so Close is its teardown.
+		_ = p.Close()
+
+		return nil, err
+	}
 
 	return p, nil
 }

--- a/local/track_internal_test.go
+++ b/local/track_internal_test.go
@@ -1,0 +1,45 @@
+package local
+
+import (
+	"testing"
+
+	"github.com/ruffel/invoke"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTrackRefusesAProcessAfterClose pins the guard that keeps a process
+// from being registered into a closed environment.
+//
+// Start checks the closed flag at entry and then starts the process and
+// wires its streams. A Close in that window has already gathered the
+// processes it will terminate, so one added afterwards would run with
+// nothing left to stop it. track must refuse it instead, and leave the
+// active set untouched, so Start knows to tear the process down.
+func TestTrackRefusesAProcessAfterClose(t *testing.T) {
+	t.Parallel()
+
+	env := &Environment{active: make(map[*process]struct{})}
+
+	p := &process{}
+
+	require.NoError(t, env.track(p), "an open environment must accept a process")
+
+	_, registered := env.active[p]
+	assert.True(t, registered, "an accepted process must be registered for termination")
+
+	// The environment closes while a second Start is between its own entry
+	// check and this point.
+	env.mu.Lock()
+	env.closed = true
+	env.mu.Unlock()
+
+	other := &process{}
+
+	err := env.track(other)
+	require.ErrorIs(t, err, invoke.ErrClosed, "track into a closed environment must refuse with ErrClosed")
+
+	_, leaked := env.active[other]
+	assert.False(t, leaked,
+		"a refused process must not be registered, or Close will already have passed it by")
+}

--- a/ssh/environment.go
+++ b/ssh/environment.go
@@ -315,11 +315,27 @@ func (e *Environment) checkOpen(op string) error {
 	return nil
 }
 
-func (e *Environment) track(p *process) {
+// track registers a running process so Close can terminate it, unless the
+// connection has closed in the meantime.
+//
+// Start checks the closed flag once at entry and then opens a session and
+// starts the command, several round-trips later. A Close landing in that
+// window has already gathered the processes it will terminate, so one
+// added afterwards would run with nothing left to stop it. Re-checking
+// here under the same lock closes that gap: a process is either registered
+// before Close snapshots, and terminated with the rest, or refused, and
+// torn down by its caller.
+func (e *Environment) track(p *process) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	if e.closed {
+		return fmt.Errorf("ssh: start: %w", invoke.ErrClosed)
+	}
+
 	e.active[p] = struct{}{}
+
+	return nil
 }
 
 func (e *Environment) untrack(p *process) {

--- a/ssh/process.go
+++ b/ssh/process.go
@@ -91,7 +91,14 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 		return nil, &invoke.TransportError{Op: "start", Err: err}
 	}
 
-	e.track(p)
+	if err := e.track(p); err != nil {
+		// The connection closed while the command was being started. Tear
+		// it down rather than leave it running past the environment that
+		// owns it; the command is fully started, so Close is its teardown.
+		_ = p.Close()
+
+		return nil, err
+	}
 
 	go p.monitorContext(ctx)
 

--- a/ssh/track_internal_test.go
+++ b/ssh/track_internal_test.go
@@ -1,0 +1,46 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/ruffel/invoke"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTrackRefusesAProcessAfterClose pins the guard that keeps a process
+// from being registered into a closed environment.
+//
+// Start checks the closed flag at entry and then opens a session and
+// starts the command several round-trips later. A Close in that window has
+// already gathered the processes it will terminate, so one added
+// afterwards would run with nothing left to stop it. track must refuse it
+// instead, and leave the active set untouched, so Start knows to tear the
+// session down.
+func TestTrackRefusesAProcessAfterClose(t *testing.T) {
+	t.Parallel()
+
+	env := &Environment{active: make(map[*process]struct{})}
+
+	p := &process{}
+
+	require.NoError(t, env.track(p), "an open environment must accept a process")
+
+	_, registered := env.active[p]
+	assert.True(t, registered, "an accepted process must be registered for termination")
+
+	// The connection closes while a second Start is between its own entry
+	// check and this point.
+	env.mu.Lock()
+	env.closed = true
+	env.mu.Unlock()
+
+	other := &process{}
+
+	err := env.track(other)
+	require.ErrorIs(t, err, invoke.ErrClosed, "track into a closed environment must refuse with ErrClosed")
+
+	_, leaked := env.active[other]
+	assert.False(t, leaked,
+		"a refused process must not be registered, or Close will already have passed it by")
+}


### PR DESCRIPTION
Wave 1 follow-up to #9 — closes the same Start/Close TOCTOU (audit M5) in the two providers #9 flagged but left. Two atomic commits, one per provider.

## The bug (identical to #9)

Each `Start` checks `closed` once at entry, then does its setup — `ssh` opens a session and starts the command; `local` starts the process and wires streams — before calling `track(p)`, which never re-checked. A `Close` in that window snapshots the active set without `p`, terminates it, and `Start` then hands back a **running** process into a closed environment with a nil error. Violates "after Close every method fails with ErrClosed" and "running processes are terminated."

Their setup windows are narrower than docker's (no daemon round-trips), but the class is the same, and after #9 these were *known* bugs sitting in `main`.

## The fix

`track` re-checks `closed` under the lock that guards the active set. A refused process is torn down by its caller — and unlike docker (whose pumps hadn't started, needing a bespoke `discard()`), here the process is **fully started** by the time `track` is reached, so `p.Close()` is the correct teardown: the very same signal-and-close `env.Close()` applies to each tracked process. No new teardown code.

## Testing

Each provider gets the same deterministic internal test as docker's #9: `track` into a closed environment must refuse with `ErrClosed` and leave the active set untouched. **Both fail without the re-check**, verified.

As in #9, I did **not** add an end-to-end race test — the same reasoning holds (closing the transport unblocks a leaked `Wait`, so a survivor is indistinguishable through the handle). The deterministic unit test is the proof.

## Verification

- `just check` green; `-tags openssh` lane green against a real server.
- Every ssh and local contract still passes — the guard only fires when a Close genuinely races a Start.

With this, all three providers guard the window identically, and the interface's "nothing outlives Close" holds the same way on each. The remaining thought from #9 — a Wave 2 `concurrent-start-and-close` **contract** to enforce this across any future provider — still stands; these three fixes are what it would check.