### PR TITLE
fix(transfer): Detect an overlapping destination reached through a symlink

### DIFF
--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -180,11 +180,58 @@ func (e endpoints) guardOverlap(absSrc, absDst string, srcInfo fs.FileInfo) erro
 		}
 	}
 
-	if srcInfo.IsDir() && e.src.Contains(absSrc, absDst) {
+	// A symlink on the way to the destination can point back into the
+	// source, which a check on the paths as written would miss: the walk
+	// then copies the tree into itself and recurses until the names grow
+	// too long to create. Resolve both sides through the components that
+	// exist, so where the destination truly lands is what the guard sees
+	// rather than how the caller happened to spell it.
+	realSrc := resolveExisting(e.src, absSrc)
+	realDst := resolveExisting(e.dst, absDst)
+
+	if realSrc == realDst {
+		return fmt.Errorf("source %q and destination %q resolve to the same path %q", absSrc, absDst, realSrc)
+	}
+
+	if srcInfo.IsDir() && e.src.Contains(realSrc, realDst) {
 		return fmt.Errorf("destination %q is inside the source tree %q", absDst, absSrc)
 	}
 
 	return nil
+}
+
+// resolveExisting resolves the longest existing prefix of path through any
+// symlinks and re-appends the components that do not exist yet, so a
+// destination that has not been created can still be placed relative to
+// where its existing parents actually lead. A path that cannot be resolved
+// at all is returned unchanged, leaving the caller no worse off than a
+// purely lexical check.
+func resolveExisting(fsys FS, path string) string {
+	remainder := ""
+	current := path
+
+	for {
+		if resolved, err := fsys.Resolve(current); err == nil {
+			if remainder == "" {
+				return resolved
+			}
+
+			return fsys.Join(resolved, remainder)
+		}
+
+		parent := fsys.Dir(current)
+		if parent == current {
+			return path
+		}
+
+		if remainder == "" {
+			remainder = fsys.Base(current)
+		} else {
+			remainder = fsys.Join(fsys.Base(current), remainder)
+		}
+
+		current = parent
+	}
 }
 
 // copyTree copies the directory tree rooted at absSrc to absDst. Directory

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -214,6 +214,83 @@ func TestCopyFollowsASymlinkedDestinationRoot(t *testing.T) {
 	assert.Equal(t, "payload", string(got))
 }
 
+// TestOverlapGuardResolvesASymlinkedDestination pins the guard against a
+// destination that reaches back into the source through a symlink.
+//
+// The paths as written do not overlap — "link/sub" is not lexically inside
+// "real" — but "link" resolves to "real", so the copy would write the tree
+// into itself and recurse until the names grow too long. The guard must
+// see the resolved destination and refuse before anything is created.
+func TestOverlapGuardResolvesASymlinkedDestination(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	srcTree := filepath.Join(base, "real")
+
+	require.NoError(t, os.MkdirAll(srcTree, 0o755), "source tree")
+	require.NoError(t, os.WriteFile(filepath.Join(srcTree, "f.txt"), []byte("payload"), 0o600), "writing fixture")
+	require.NoError(t, os.Symlink(srcTree, filepath.Join(base, "link")), "symlink")
+
+	err := transfer.Copy(t.Context(), transfer.HostFS{}, srcTree,
+		transfer.HostFS{}, filepath.Join(base, "link", "sub"), invoke.TransferConfig{})
+	require.Error(t, err, "a copy into a symlink that resolves inside the source reported success")
+
+	assert.ErrorContains(t, err, "inside the source tree",
+		"the guard did not recognize the destination as overlapping; it recursed instead")
+
+	// The guard runs before anything is created, so the source stays as it
+	// was — no tree copied into itself.
+	_, err = os.Stat(filepath.Join(srcTree, "sub"))
+	assert.Error(t, err, "the copy created entries inside the source before refusing")
+}
+
+// TestOverlapGuardResolvesToTheSamePath pins the case where the
+// destination is a different name for the source itself.
+func TestOverlapGuardResolvesToTheSamePath(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	srcTree := filepath.Join(base, "real")
+
+	require.NoError(t, os.MkdirAll(srcTree, 0o755), "source tree")
+	require.NoError(t, os.Symlink(srcTree, filepath.Join(base, "link")), "symlink")
+
+	err := transfer.Copy(t.Context(), transfer.HostFS{}, srcTree,
+		transfer.HostFS{}, filepath.Join(base, "link"), invoke.TransferConfig{})
+	require.Error(t, err, "a copy onto a symlink to the source itself reported success")
+
+	assert.ErrorContains(t, err, "resolve to the same path",
+		"the guard did not recognize the destination as the source under another name")
+}
+
+// TestOverlapGuardAllowsAnUnrelatedSymlinkedDestination guards the other
+// side of the rule: resolving must not reject a destination reached
+// through a symlink that leads somewhere else entirely — the ordinary
+// current-points-at-a-release deploy shape.
+func TestOverlapGuardAllowsAnUnrelatedSymlinkedDestination(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+
+	src := filepath.Join(base, "build")
+	require.NoError(t, os.MkdirAll(src, 0o755), "source tree")
+	require.NoError(t, os.WriteFile(filepath.Join(src, "app"), []byte("payload"), 0o600), "writing fixture")
+
+	release := filepath.Join(base, "release")
+	require.NoError(t, os.MkdirAll(release, 0o755), "release directory")
+	require.NoError(t, os.Symlink(release, filepath.Join(base, "current")), "symlink")
+
+	require.NoError(t,
+		transfer.Copy(t.Context(), transfer.HostFS{}, src,
+			transfer.HostFS{}, filepath.Join(base, "current", "app"), invoke.TransferConfig{}),
+		"a copy through a symlink that leads outside the source must be allowed")
+
+	got, err := os.ReadFile(filepath.Join(release, "app", "app"))
+	require.NoError(t, err, "reading the transferred file")
+
+	assert.Equal(t, "payload", string(got))
+}
+
 // TestCopyRejectsCanceledContext checks the engine refuses before it
 // creates anything, including for a source with no entries to check.
 func TestCopyRejectsCanceledContext(t *testing.T) {


### PR DESCRIPTION
Wave 1 — audit finding S2b (overlap guard is lexical). Independent of the open PRs.

## The bug

`guardOverlap` checked containment with a lexical prefix (`Contains(absSrc, absDst)`), so a destination whose parents lead back into the source **through a symlink** was not seen as overlapping. Reproduced in the audit:

```
Upload(real, link/sub)   # link -> real
=> real/sub/sub/sub/…    # copies the tree into itself, recurses to ENAMETOOLONG
```

"link/sub" is not lexically inside "real", so the guard waved it through and the walk recursed until the path was too long to create — the exact failure the guard exists to prevent, arriving the long way round.

## The fix

Resolve both sides through the components that exist, then compare:

- resolves **onto** the source → refused as the same path;
- resolves **inside** it → refused as overlapping;
- unresolvable → falls back to the written form, no worse than before.

`resolveExisting` walks up to the longest existing prefix, resolves it (`EvalSymlinks`), and re-appends the not-yet-created remainder — so a destination that doesn't exist yet is still placed where its real parents lead.

## Scope

This only bears on **same-filesystem** transfers, where a path on one side means something on the other — i.e. the **local** provider and the **fake**. `guardOverlap` already stands aside for host↔remote copies (ssh, docker), which cannot alias, so their behavior is unchanged. The integration lanes still ran green, confirming the shared engine's other paths are undisturbed.

## Tests (all in the default lane)

- **`TestOverlapGuardResolvesASymlinkedDestination`** — drives the audit's recursion; asserts it's refused with "inside the source tree" **and that nothing was created**. Fails without the fix with the literal `file name too long` from the recursion.
- **`TestOverlapGuardResolvesToTheSamePath`** — destination is the source under another name. Fails without the fix.
- **`TestOverlapGuardAllowsAnUnrelatedSymlinkedDestination`** — the boundary the resolution must *not* cross: a symlinked destination leading elsewhere (the `current -> release` deploy). Guards against over-rejection; passes both ways by design.

## Verification

- `just check` green; existing overlap tests (`TestSamePathIsRejectedAndDataSurvives`, `TestDestinationInsideSourceIsRejected`) still pass.
- Both `-tags openssh` and `-tags docker` lanes green against real servers.