### PR TITLE
fix(docker): Move an upload into place on one filesystem

### DIFF
--- a/docker/container_test.go
+++ b/docker/container_test.go
@@ -64,6 +64,14 @@ func newClient(t *testing.T) *client.Client {
 func startContainer(t *testing.T) string {
 	t.Helper()
 
+	return startContainerWith(t, &container.HostConfig{})
+}
+
+// startContainerWith starts the test image under a caller-supplied host
+// configuration, for the few tests that need one — a read-only mount, say.
+func startContainerWith(t *testing.T, hostCfg *container.HostConfig) string {
+	t.Helper()
+
 	cli := newClient(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -75,7 +83,7 @@ func startContainer(t *testing.T) string {
 		Image: testImage,
 		// Idle forever: the contracts exec into a running container.
 		Cmd: []string{"sleep", "infinity"},
-	}, &container.HostConfig{}, nil, nil, "")
+	}, hostCfg, nil, nil, "")
 	require.NoError(t, err, "creating the container")
 
 	require.NoError(t, cli.ContainerStart(ctx, created.ID, container.StartOptions{}), "starting the container")

--- a/docker/files.go
+++ b/docker/files.go
@@ -39,7 +39,16 @@ func (e *Environment) Upload(ctx context.Context, localPath, remotePath string, 
 		return fmt.Errorf("docker: upload: %w", err)
 	}
 
-	staging := stagingDir()
+	// Stage inside the destination's own directory rather than a fixed
+	// path like /tmp, so the move into place is a rename on one filesystem
+	// — atomic, and never a copy across a boundary that could fail with
+	// the destination already gone.
+	dstDir := path.Dir(dst)
+	if err := e.makeRemoteDir(ctx, dstDir); err != nil {
+		return fmt.Errorf("docker: upload: %w", err)
+	}
+
+	staging := path.Join(dstDir, ".invoke-xfer-"+randomSuffix())
 	if err := e.makeRemoteDir(ctx, staging); err != nil {
 		return fmt.Errorf("docker: upload: %w", err)
 	}
@@ -53,11 +62,9 @@ func (e *Environment) Upload(ctx context.Context, localPath, remotePath string, 
 		return fmt.Errorf("docker: upload: %w", err)
 	}
 
-	if err := e.makeRemoteDir(ctx, path.Dir(dst)); err != nil {
-		return fmt.Errorf("docker: upload: %w", err)
-	}
+	aside := dst + ".invoke-old-" + randomSuffix()
 
-	if err := e.moveRemote(ctx, path.Join(staging, name), dst); err != nil {
+	if err := e.moveRemote(ctx, path.Join(staging, name), dst, aside); err != nil {
 		return fmt.Errorf("docker: upload: %w", err)
 	}
 
@@ -222,11 +229,6 @@ func normalizeRemote(p string) (string, error) {
 	return path.Clean(p), nil
 }
 
-// stagingDir names a directory no concurrent transfer will collide with.
-func stagingDir() string {
-	return "/tmp/.invoke-xfer-" + randomSuffix()
-}
-
 // makeRemoteDir creates a directory and its parents in the container.
 func (e *Environment) makeRemoteDir(ctx context.Context, dir string) error {
 	_, code, err := e.runRaw(ctx, []string{"mkdir", "-p", dir})
@@ -242,13 +244,24 @@ func (e *Environment) makeRemoteDir(ctx context.Context, dir string) error {
 }
 
 // moveRemote replaces dst with src inside the container.
-func (e *Environment) moveRemote(ctx context.Context, src, dst string) error {
-	// A directory destination has to go first: mv would otherwise place
-	// the source inside it rather than in its place.
-	script := `if [ -d "$2" ] && [ ! -L "$2" ]; then rm -rf -- "$2"; fi
-exec mv -f -- "$1" "$2"`
+func (e *Environment) moveRemote(ctx context.Context, src, dst, aside string) error {
+	// Staging shares the destination's directory, so each mv here is a
+	// rename on one filesystem. An existing destination is set aside rather
+	// than removed, and only cleared once the new one is in its place, so a
+	// move that fails leaves the original recoverable and restored — never
+	// a destination deleted ahead of a replacement that did not arrive.
+	script := `if [ -e "$2" ] || [ -L "$2" ]; then
+	mv -f -- "$2" "$3" || exit 1
+	if ! mv -f -- "$1" "$2"; then
+		mv -f -- "$3" "$2"
+		exit 1
+	fi
+	rm -rf -- "$3"
+else
+	mv -f -- "$1" "$2" || exit 1
+fi`
 
-	_, code, err := e.runRaw(ctx, []string{"sh", "-c", script, "sh", src, dst})
+	_, code, err := e.runRaw(ctx, []string{"sh", "-c", script, "sh", src, dst, aside})
 	if err != nil {
 		return err
 	}

--- a/docker/upload_atomicity_test.go
+++ b/docker/upload_atomicity_test.go
@@ -1,0 +1,85 @@
+//go:build docker
+
+package docker_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/ruffel/invoke"
+	"github.com/ruffel/invoke/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUploadStagesOnTheDestinationFilesystem pins that an upload does not
+// depend on /tmp, and by extension that its move into place is a rename on
+// the destination's own filesystem rather than a copy across a boundary.
+//
+// The container's /tmp is mounted read-only. Staging there — as a fixed
+// staging path once did — fails outright; staging in the destination's own
+// directory, which is writable, does not. A move that has to cross from
+// /tmp to the destination is also the move that cannot be atomic, so the
+// same change removes both problems.
+func TestUploadStagesOnTheDestinationFilesystem(t *testing.T) {
+	t.Parallel()
+
+	id := startContainerWith(t, &container.HostConfig{
+		Tmpfs: map[string]string{"/tmp": "ro"},
+	})
+
+	env, err := docker.New(t.Context(), id)
+	require.NoError(t, err, "docker.New")
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	local := filepath.Join(t.TempDir(), "payload.txt")
+	require.NoError(t, os.WriteFile(local, []byte("delivered"), 0o600), "writing fixture")
+
+	// /data is on the writable root filesystem, not the read-only /tmp.
+	require.NoError(t, env.Upload(t.Context(), local, "/data/payload.txt"),
+		"upload must stage on the destination's filesystem, not depend on /tmp being writable")
+
+	_, stdout, _, err := invoke.NewExecutor(env).Output(t.Context(), invoke.New("cat", "/data/payload.txt"))
+	require.NoError(t, err, "reading the uploaded file")
+
+	assert.Equal(t, "delivered", string(stdout), "the upload did not arrive at the destination")
+}
+
+// TestUploadReplacesAnExistingDirectory pins that uploading a directory
+// over one already there replaces it rather than merging into it, and
+// leaves nothing of the old contents behind — the behaviour the aside-move
+// has to preserve now that it no longer removes the destination up front.
+func TestUploadReplacesAnExistingDirectory(t *testing.T) {
+	t.Parallel()
+
+	id := startContainer(t)
+
+	env, err := docker.New(t.Context(), id)
+	require.NoError(t, err, "docker.New")
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	exec := invoke.NewExecutor(env)
+
+	// An existing destination directory with a file the new tree does not
+	// contain.
+	_, err = exec.Run(t.Context(),
+		invoke.Shell("mkdir -p /data/target && echo stale > /data/target/old.txt"), invoke.IO{})
+	require.NoError(t, err, "seeding the existing destination")
+
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "new.txt"), []byte("fresh"), 0o600), "writing fixture")
+
+	require.NoError(t, env.Upload(t.Context(), srcDir, "/data/target"), "upload over an existing directory")
+
+	_, stdout, _, err := exec.Output(t.Context(), invoke.New("cat", "/data/target/new.txt"))
+	require.NoError(t, err, "reading the replacement content")
+	assert.Equal(t, "fresh", string(stdout), "the new content did not arrive")
+
+	// The old file must be gone: a replacement, not a merge.
+	_, err = exec.Run(t.Context(), invoke.New("test", "-e", "/data/target/old.txt"), invoke.IO{})
+	require.Error(t, err, "the destination kept a file from before the upload; it was merged, not replaced")
+}


### PR DESCRIPTION
Wave 1 — audit finding M4 (upload not atomic; can lose an existing destination). Last of the Wave 1 correctness items.

## The bug

Upload staged under a fixed `/tmp/.invoke-xfer-*`, then `moveRemote` did:

```sh
if [ -d "$2" ] && [ ! -L "$2" ]; then rm -rf -- "$2"; fi   # remove the destination…
exec mv -f -- "$1" "$2"                                     # …then move onto it
```

When `/tmp` and the destination are on **different filesystems** — which a tmpfs `/tmp` or a volume-mounted destination makes ordinary — `mv` is not a rename but a recursive copy. And for a directory destination the original was `rm -rf`'d **before** that copy ran. A copy that failed part-way (disk full, interrupted) then left the destination **neither old nor new**: gone, with a partial tree in its place. That's the legacy truncation class in new clothes.

## The fix

Two changes, one idea — keep the whole operation on the destination's own filesystem:

1. **Stage inside the destination's directory**, not `/tmp`. The final move is now a rename on one filesystem: atomic, no partial state to be caught in.
2. **Set an existing destination aside instead of removing it**, and clear it only once the replacement is in place. A move that somehow fails restores the original rather than losing it.

```sh
if [ -e "$2" ] || [ -L "$2" ]; then
    mv -f -- "$2" "$3" || exit 1        # destination -> aside
    if ! mv -f -- "$1" "$2"; then
        mv -f -- "$3" "$2"              # restore on failure
        exit 1
    fi
    rm -rf -- "$3"
else
    mv -f -- "$1" "$2" || exit 1
fi
```

This mirrors how the `local` provider guarantees atomicity by staging in the destination directory.

## Tests (tagged lane)

- **`TestUploadStagesOnTheDestinationFilesystem`** — the provable-failure test. The container's `/tmp` is mounted **read-only**; the upload must still succeed, which it cannot if it stages there. **Fails against the previous behaviour**, verified. This directly pins the staging-filesystem fix (a move that must cross from `/tmp` is exactly the move that can't be atomic, so the same change removes both problems).
- **`TestUploadReplacesAnExistingDirectory`** — checks a directory upload *replaces* rather than *merges into* an existing one (old file gone), the property the aside-move must preserve now that it doesn't clear the destination first.

**On the restore branch:** the failure-recovery `mv "$3" "$2"` is the standard rename-aside pattern and is **not** exercised on its own, because a same-filesystem rename can't be made to fail on demand without a seam. Flagging that explicitly rather than implying full coverage — the safety there is by construction, and the destination is never destroyed ahead of the replacement regardless.

## Verification

- `just check` green; docker lint (with `--build-tags docker`) clean; full `-tags docker` lane green against a live daemon (contracts + parity + transfers).
- `startContainer` refactored to a `startContainerWith(hostCfg)` helper so the read-only-`/tmp` case can set a mount; the no-arg form is unchanged.