### PR TITLE
build: Verify the submodule stays tidy; add a security policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
         run: cd docker && golangci-lint fmt --diff ./...
       - name: Check go.mod is tidy
         run: go mod tidy -diff
+      - name: Check the docker module's go.mod is tidy
+        # Resolved with the workspace off, the way a consumer meets it:
+        # against the published core version its go.mod names.
+        run: cd docker && GOWORK=off go mod tidy -diff
 
   windows-build:
     name: Windows cross-build

--- a/Justfile
+++ b/Justfile
@@ -90,17 +90,20 @@ fmt-check:
     golangci-lint fmt --diff ./...
     cd docker && golangci-lint fmt --diff ./...
 
-# Tidy go.mod/go.sum.
+# Tidy go.mod/go.sum in both modules.
 #
-# The docker module is omitted until the core module is released: it
-# resolves the core module through the workspace, and tidy would try to
-# fetch a version that does not exist yet.
+# The submodule is tidied with the workspace off, the way a consumer
+# resolves it: against the published core module its go.mod names, not the
+# local checkout the workspace would substitute. That version now exists,
+# so the submodule is no longer maintained by hand.
 tidy:
     go mod tidy
+    cd docker && GOWORK=off go mod tidy
 
-# Fail if go.mod/go.sum need tidying.
+# Fail if either module's go.mod/go.sum needs tidying.
 tidy-check:
     go mod tidy -diff
+    cd docker && GOWORK=off go mod tidy -diff
 
 # Check the tree is ready to be tagged as VERSION (e.g. v0.2.0).
 #

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately, through GitHub's
+[private vulnerability reporting][advisory] — open the repository's
+**Security** tab and choose **Report a vulnerability**. This keeps the
+report confidential until a fix is available.
+
+Please do not open a public issue for a security report.
+
+A report is most useful when it includes the affected version, the
+provider it concerns (local, ssh, or docker), and the smallest set of
+steps that reproduces the behaviour. You can expect an acknowledgement
+within a few days.
+
+[advisory]: https://github.com/ruffel/invoke/security/advisories/new
+
+## Supported versions
+
+The library is pre-1.0, so fixes land on the current release line and a
+corrected version is published rather than patched in place. There is no
+long-term support for earlier lines: upgrading to the latest release is
+the way to receive a fix.
+
+## Scope
+
+This library runs commands and moves files on targets the caller names —
+the local machine, a remote host over SSH, a container. Two boundaries
+are worth stating, because they shape what counts as a vulnerability:
+
+- **The command is the caller's.** The API runs what it is given, with no
+  shell interpretation unless [`Shell`] is used, in which case quoting is
+  the caller's responsibility. A command that harms its own target is not
+  a vulnerability in the library.
+- **The target may be untrusted; the caller's machine is defended from
+  it.** A file transfer must not let a hostile target write outside the
+  destination the caller chose, and an interrupted command must not be
+  reported as one that certainly ran. Failures of that kind are in scope.
+
+[`Shell`]: https://pkg.go.dev/github.com/ruffel/invoke#Shell


### PR DESCRIPTION
Two release-hygiene items that were outstanding.

## Verify the submodule's go.mod stays tidy

`just tidy` / `tidy-check` and the CI lint job checked only the root module. The submodule was deliberately left out *while the core module had no published version for it to resolve* — tidying it would have tried to fetch something that didn't exist yet. That version exists now (v0.2.0, v0.3.0), but the omission outlived its reason across two releases, so `docker/go.mod` has been verified **nowhere**.

Both recipes and the CI lint job now tidy-check the submodule too, with `GOWORK=off` so it resolves the **published** core version its go.mod names, not the local checkout the workspace would substitute — i.e. the way a consumer actually meets it. Verified clean today, both with the workspace and with it off.

## Add SECURITY.md

The library had no stated way to report a vulnerability privately — a gap for one that runs commands and moves files across trust boundaries. The policy routes reports through GitHub's private advisories, states how fixes ship before 1.0 (corrected release, no back-patching), and draws the two scope boundaries that decide what counts as a vulnerability: the command is the caller's, and the caller's machine is defended from an untrusted target even when the command isn't.

> Note: the reporting link assumes private vulnerability reporting is enabled for the repo (Settings → Code security → *Private vulnerability reporting*). One click if it isn't already on.

## What I deliberately left out — and a correction to my own audit

The audit flagged the `go 1.25.0` directive as a regression against the design's "declare the minor only (`go 1.25`)" note, to be stripped to `go 1.25`. **On inspection that's wrong, and I'm not making that change:**

- `go mod tidy` under the Go 1.25.6 toolchain **rewrites `go 1.25` back to `go 1.25.0`** — the patch form is what Go 1.21+ canonicalizes to. I confirmed it with a real `GOWORK=off go mod tidy`, not just `-diff`.
- So `go 1.25` is not tidy-stable: setting it would make the very tidy-check this PR adds **fail**.
- And it buys nothing — `go 1.25` and `go 1.25.0` impose the identical minimum (Go ≥ 1.25.0).

The design's "minor only" preference predates Go 1.21's directive semantics and is no longer achievable. The current `go 1.25.0` is correct. (If the goal were ever to widen the consumer base, the real lever is *lowering* the minimum minor — a separate change gated on a language-feature audit, not a notation strip.)

## Verification

- `just check` green, including the new `cd docker && GOWORK=off go mod tidy -diff` step.
- No code touched; Justfile, CI workflow, and a new docs file only.