### PR TITLE
test(invoketest): Forbid dressing a terminal outcome as a transport failure

### DIFF
--- a/invoketest/contracts_errors.go
+++ b/invoketest/contracts_errors.go
@@ -13,6 +13,7 @@ func errorsContracts() []TestCase {
 		errorsBadWorkdirClassified(),
 		errorsLookPathClassifies(),
 		errorsClosedEnvRefusesAll(),
+		errorsTerminalOutcomesAreNotTransport(),
 	}
 }
 
@@ -103,6 +104,47 @@ func errorsLookPathClassifies() TestCase {
 
 			_, err = env.LookPath(t.Context(), "invoke-definitely-missing-"+token(t))
 			assert.ErrorIs(t, err, invoke.ErrNotFound, "LookPath of an unresolvable name")
+		},
+	}
+}
+
+func errorsTerminalOutcomesAreNotTransport() TestCase {
+	return TestCase{
+		Category: CategoryErrors,
+		Name:     "terminal-outcomes-are-not-transport",
+		Description: "An outcome that forecloses retrying — a command that ran, or one that could not " +
+			"be started for a settled reason — must never classify as a retryable TransportError",
+		Run: func(t T, env invoke.Environment) {
+			ctx := t.Context()
+
+			// The command ran and failed. Retrying it could run it again,
+			// so a non-zero exit is terminal however it is reported.
+			exit, _, _ := runCapture(t, env, invoke.Shell("exit 3"))
+			requireNotTransport(t, exit.err, "a non-zero exit")
+
+			// Could not be started, for reasons asking again will not
+			// change: the binary is not there, the directory is not there.
+			_, notFound := env.Start(ctx, invoke.New("invoke-missing-"+token(t)), invoke.IO{})
+			requireNotTransport(t, notFound, "a missing binary")
+
+			badDir := invoke.New("true")
+			badDir.Dir = "/invoke-no-such-dir-" + token(t)
+
+			_, badWorkdir := env.Start(ctx, badDir, invoke.IO{})
+			requireNotTransport(t, badWorkdir, "an invalid working directory")
+
+			// A feature the target declares it cannot provide is settled
+			// too — only targets that lack it can be asked to prove this.
+			if !env.Capabilities().TTY {
+				_, unsupported := env.Start(ctx, invoke.New("true"), invoke.IO{TTY: &invoke.TTY{}})
+				requireNotTransport(t, unsupported, "an unsupported TTY request")
+			}
+
+			// After Close, every call is terminal.
+			require.NoError(t, env.Close(), "closing the environment")
+
+			_, closed := env.Start(ctx, invoke.New("true"), invoke.IO{})
+			requireNotTransport(t, closed, "a closed environment")
 		},
 	}
 }

--- a/invoketest/helpers.go
+++ b/invoketest/helpers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ruffel/invoke"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -143,6 +144,21 @@ func requireNotExitError(t T, err error, situation string) {
 
 	require.NotErrorAsf(t, err, &exitErr,
 		"%s surfaced as *ExitError; lifecycle errors must never be command outcomes", situation)
+}
+
+// requireNotTransport fails the contract when a terminal outcome — one a
+// caller cannot safely have retried — is classified as a TransportError,
+// the one family the executor does retry. It asserts rather than requires,
+// so a contract can weigh several outcomes and report each violation.
+func requireNotTransport(t T, err error, situation string) {
+	t.Helper()
+
+	assert.Errorf(t, err, "%s must produce an error to classify", situation)
+
+	var te *invoke.TransportError
+
+	assert.NotErrorAsf(t, err, &te,
+		"%s is terminal and must never be retried, yet it classifies as a TransportError", situation)
 }
 
 // closeOrTimeout closes proc with the contract deadline, so a Close that

--- a/invoketest/misbehave_test.go
+++ b/invoketest/misbehave_test.go
@@ -64,6 +64,7 @@ type defects struct {
 	plainMissingBinary bool // strip ErrNotFound from missing-binary failures
 	plainWorkdirError  bool // strip ErrInvalidWorkdir from workdir failures
 	plainLookPathError bool // strip ErrNotFound from LookPath failures
+	launderTerminal    bool // dress a terminal outcome up as a retryable transport failure
 
 	// Transfer defects.
 	corruptUploads           bool // upload garbage in place of the source
@@ -123,6 +124,10 @@ func (m *misbehaveEnv) Start(ctx context.Context, cmd invoke.Command, stdio invo
 
 		if m.d.plainWorkdirError && errors.Is(err, invoke.ErrInvalidWorkdir) {
 			return nil, errors.New("misbehave: something went wrong")
+		}
+
+		if m.d.launderTerminal && isTerminalStartError(err) {
+			return nil, &invoke.TransportError{Op: "start", Err: err}
 		}
 
 		return nil, err
@@ -519,6 +524,8 @@ func (p *misbehaveProcess) corruptError(res invoke.Result, err error) (waitOutco
 	}
 
 	switch {
+	case p.d.launderTerminal:
+		return waitOutcome{result: res, err: &invoke.TransportError{Op: "wait", Err: err}}, true
 	case p.d.collapseSignalNames && exitErr.Signal != "":
 		return waitOutcome{result: res, err: &invoke.ExitError{Code: exitErr.Code, Signal: invoke.SIGTERM}}, true
 	case p.d.clampExitCode && exitErr.Code >= signalBoundary:
@@ -543,6 +550,18 @@ func asExitError(err error) *invoke.ExitError {
 	}
 
 	return nil
+}
+
+// isTerminalStartError reports whether a Start failure is one that asking
+// again will not change — the families the executor treats as terminal, so
+// the launderTerminal defect knows which errors to disguise as retryable.
+// Cancellation is deliberately excluded: a provider's own per-attempt
+// deadline is a context error inside a genuine transport failure.
+func isTerminalStartError(err error) bool {
+	return errors.Is(err, invoke.ErrNotFound) ||
+		errors.Is(err, invoke.ErrInvalidWorkdir) ||
+		errors.Is(err, invoke.ErrClosed) ||
+		errors.Is(err, invoke.ErrNotSupported)
 }
 
 // neverEOFReader blocks forever, simulating an inherited terminal stdin.
@@ -652,6 +671,7 @@ func defectCatalog() []defectCase {
 		{name: "unclassified lookpath", contract: "errors/lookpath-classifies", defects: defects{plainLookPathError: true}},
 		{name: "bare lookpath name", contract: "errors/lookpath-classifies", defects: defects{bareLookPath: true}},
 		{name: "env close no-op refusal", contract: "errors/closed-env-refuses-all", defects: defects{envCloseNoOp: true}},
+		{name: "terminal laundered as transport", contract: "errors/terminal-outcomes-are-not-transport", defects: defects{launderTerminal: true}},
 
 		{name: "corrupted uploads", contract: "transfer/roundtrip-preserves-content-and-mode", defects: defects{corruptUploads: true}},
 		{name: "corrupted binary", contract: "transfer/binary-content-survives", defects: defects{corruptUploads: true}},


### PR DESCRIPTION
Makes the retry-safety property the executor depends on enforceable for any provider, including ones outside this module.

## The gap

Only a `TransportError` is retried, because only it says the command didn't run. Everything else is terminal. The suite checked that each terminal outcome was classified as *its own* kind (exit → `ExitError`, missing binary → `ErrNotFound`, …) — but never that none of them was **also** a `TransportError`. And `TransportError` unwraps, so one wrapping a terminal outcome answers to both families at once:

```go
&TransportError{Err: &ExitError{Code: 1}}
// errors.As(err, **ExitError)      -> true   (every existing assertion still passes)
// errors.As(err, **TransportError) -> true   (and the executor retries it)
```

A provider could carry an exit, a missing binary, or a closed environment inside a `TransportError`, satisfy every classification contract, and have the executor **run the command again** — the exact legacy `ExitMissingError` disaster. #4 fixed this in the executor by construction; this makes it a property providers are held to, which is where the design says classification belongs.

## The contract

`errors/terminal-outcomes-are-not-transport` drives each terminal outcome and requires none is a `TransportError`:

- a non-zero exit (ran and failed),
- a missing binary, an invalid working directory (couldn't start, settled reason),
- an unsupported feature — **only** on targets that declare they lack it (capability-gated, so `fake` exercises it and the others skip),
- a closed environment.

**Cancellation is deliberately excluded**, matching the executor's own `terminal()` set: a provider's per-attempt deadline is a context error inside a *genuine* transport failure, and treating it as terminal would strand a retry the caller wanted.

## Provably able to fail

A `launderTerminal` defect wraps a terminal Start or Wait error in a `TransportError`. It passes every classification the outcome already had — and is caught only by this contract. Registered in the defect catalog, so the self-test confirms the contract fails against it (and the coverage check confirms it has a defect at all).

## Verification

- Self-test lane green: contract passes against the reference, fails against `launderTerminal`.
- Passes clean against **local, fake, ssh** (in-process **and** real OpenSSH) and **docker** (live daemon). No provider was laundering — this locks that in.
- `just check` green; both integration lanes green.