### PR TITLE
test(invoketest): Complete the capability and transfer spec contracts

### DIFF
--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -44,7 +44,10 @@ func TestDockerContractSuite(t *testing.T) {
 
 	invoketest.Verify(t, func(it invoketest.T) invoke.Environment {
 		return dialContainer(asTestingT(it))
-	})
+	}, invoketest.WithKnownGap("tty/stderr-merges-into-stdout",
+		"under a requested TTY the provider captures no command output at all, though the daemon "+
+			"delivers it — the docker CLI shows the same command's output — so this is the provider's "+
+			"attach handling, not a daemon limitation; fixed separately"))
 }
 
 func TestMissingContainerIsNotFound(t *testing.T) {

--- a/invoketest/contracts_transfer.go
+++ b/invoketest/contracts_transfer.go
@@ -40,11 +40,69 @@ func transferContracts() []TestCase {
 		transferTreeCreatesParents(),
 		transferEmptyFilesAndDirs(),
 		transferSymlinksPreserve(),
+		transferSymlinkUnsupportedErrors(),
 		transferSymlinkFollowCopiesContent(),
 		transferFollowRejectsEscapes(),
 		transferSpecialFiles(),
 		transferProgressTotals(),
+		transferSamePathPreservesSource(),
 		transferCanceledBeforeStartDoesNothing(),
+	}
+}
+
+// transferSamePathPreservesSource pins the closing half of the atomicity
+// promise: a transfer whose source and destination are one file must not
+// destroy the source it is reading.
+//
+// Where the two sides share a filesystem — the local target, the fake —
+// the overlap guard refuses it. Where they cannot alias, the atomic
+// temp-and-rename delivery keeps the source intact regardless. Either way
+// the file must survive, which is the legacy failure this forbids: the
+// destination was opened truncating while the source was still open,
+// leaving zero bytes and no error.
+func transferSamePathPreservesSource() TestCase {
+	return TestCase{
+		Category:    CategoryTransfer,
+		Name:        "same-path-preserves-source",
+		Description: "A transfer whose source and destination are the same file preserves the source rather than truncating it",
+		Run: func(t T, env invoke.Environment) {
+			src := writeHostFixture(t, t.TempDir(), "precious.txt", "PRECIOUS DATA")
+
+			// Rejected or delivered, it must not destroy what it reads.
+			_ = env.Upload(t.Context(), src, src)
+
+			assert.Equal(t, "PRECIOUS DATA", readHostFile(t, src),
+				"a same-path transfer destroyed the source it was reading")
+		},
+	}
+}
+
+// transferSymlinkUnsupportedErrors is the undeclared half of the symlink
+// capability, the mirror of tty/unsupported-errors: a target that does not
+// declare link preservation must refuse a tree that carries one, wrapping
+// ErrNotSupported, rather than dropping the link and reporting success.
+func transferSymlinkUnsupportedErrors() TestCase {
+	return TestCase{
+		Category:    CategoryTransfer,
+		Name:        "symlink-unsupported-errors",
+		Description: "Without the SymlinkPreserve capability, a transfer carrying a symlink fails wrapping ErrNotSupported instead of dropping it",
+		Gate: func(caps invoke.Capabilities) (bool, string) {
+			return !caps.SymlinkPreserve, "target declares symlink preservation; transfer/symlinks-preserve covers it"
+		},
+		Run: func(t T, env invoke.Environment) {
+			srcDir := t.TempDir()
+			writeHostFixture(t, srcDir, "real.txt", "real")
+			require.NoError(t, os.Symlink("real.txt", filepath.Join(srcDir, "link.txt")), "symlink")
+
+			remote := "/tmp/invoke-xfer-" + token(t)
+			defer cleanupTargetPath(t, env, remote)
+
+			err := env.Upload(t.Context(), srcDir, remote)
+			require.Error(t, err,
+				"a transfer carrying a symlink to a target that cannot preserve links reported success")
+
+			assert.ErrorIs(t, err, invoke.ErrNotSupported)
+		},
 	}
 }
 

--- a/invoketest/contracts_tty.go
+++ b/invoketest/contracts_tty.go
@@ -1,6 +1,8 @@
 package invoketest
 
 import (
+	"bytes"
+
 	"github.com/ruffel/invoke"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -9,7 +11,37 @@ import (
 func ttyContracts() []TestCase {
 	return []TestCase{
 		ttyAllocatesTerminal(),
+		ttyStderrMergesIntoStdout(),
 		ttyUnsupportedErrors(),
+	}
+}
+
+func ttyStderrMergesIntoStdout() TestCase {
+	return TestCase{
+		Category: CategoryTTY,
+		Name:     "stderr-merges-into-stdout",
+		Description: "Under a requested TTY the process's stderr arrives on stdout, and the separate " +
+			"Stderr writer receives nothing",
+		Gate: func(caps invoke.Capabilities) (bool, string) {
+			return caps.TTY, "target does not declare TTY allocation; tty/unsupported-errors covers it"
+		},
+		Run: func(t T, env invoke.Environment) {
+			var stdout, stderr bytes.Buffer
+
+			proc := startCommand(t.Context(), t, env, invoke.Shell("echo out; echo err 1>&2"),
+				invoke.IO{Stdout: &stdout, Stderr: &stderr, TTY: &invoke.TTY{}})
+
+			result := waitOrTimeout(t, proc)
+			require.NoError(t, result.err, "the command failed under a requested TTY")
+
+			// A pseudo-terminal has one output stream, so both writes land
+			// on stdout and the caller's Stderr writer is left untouched.
+			assert.Contains(t, stdout.String(), "out", "stdout must carry the command's standard output")
+			assert.Contains(t, stdout.String(), "err",
+				"under a TTY the command's standard error must merge into stdout")
+			assert.Empty(t, stderr.String(),
+				"under a TTY there is no separate standard error; the Stderr writer must stay empty")
+		},
 	}
 }
 

--- a/invoketest/misbehave_test.go
+++ b/invoketest/misbehave_test.go
@@ -75,6 +75,8 @@ type defects struct {
 	shallowTrees             bool // upload only a tree's top-level files
 	dropSymlinks             bool // silently skip symlinks in transfers
 	followLies               bool // treat SymlinkFollow as SymlinkSkip
+	stripSymlinkPreserve     bool // report no symlink preservation, then carry links anyway instead of refusing
+	destroySamePath          bool // truncate the source when a transfer's two paths are identical
 	alwaysSkipSpecial        bool // force WithSkipSpecial regardless of options
 	zeroProgressTotals       bool // report Total as zero in progress callbacks
 	transferIgnoresCancel    bool // detach a transfer from the caller's context
@@ -150,31 +152,19 @@ func (m *misbehaveEnv) LookPath(ctx context.Context, name string) (string, error
 }
 
 func (m *misbehaveEnv) Upload(ctx context.Context, localPath, remotePath string, opts ...invoke.TransferOption) error {
+	if m.d.destroySamePath && localPath == remotePath {
+		// The legacy bug: the destination was opened truncating while the
+		// source was still open, leaving zero bytes and a nil error.
+		_ = os.WriteFile(localPath, nil, fixtureMode)
+
+		return nil
+	}
+
 	if m.d.transferIgnoresCancel {
 		ctx = context.WithoutCancel(ctx)
 	}
 
-	cfg := invoke.NewTransferConfig(opts...)
-
-	if m.d.dropModeOption {
-		cfg.Mode = nil
-	}
-
-	if m.d.dropSymlinks || m.d.followLies {
-		cfg.Symlinks = invoke.SymlinkSkip
-	}
-
-	if m.d.alwaysSkipSpecial {
-		cfg.SkipSpecial = true
-	}
-
-	if m.d.zeroProgressTotals && cfg.Progress != nil {
-		forward := cfg.Progress
-		cfg.Progress = func(p invoke.TransferProgress) {
-			p.Total = 0
-			forward(p)
-		}
-	}
+	cfg := m.mutateTransferConfig(invoke.NewTransferConfig(opts...))
 
 	src := localPath
 
@@ -253,6 +243,12 @@ func (m *misbehaveEnv) Capabilities() invoke.Capabilities {
 	// to present itself as one — whatever the wrapped target can do.
 	if m.d.stripTTY {
 		caps.TTY = false
+	}
+
+	// The mirror of stripTTY for transfers: a target that claims it cannot
+	// preserve links, then carries them anyway rather than refusing.
+	if m.d.stripSymlinkPreserve {
+		caps.SymlinkPreserve = false
 	}
 
 	return caps
@@ -374,6 +370,32 @@ func (m *misbehaveEnv) mutateCommand(cmd invoke.Command) invoke.Command {
 	}
 
 	return cmd
+}
+
+// mutateTransferConfig applies the option-rewriting transfer defects,
+// separated from Upload so its own branching stays legible.
+func (m *misbehaveEnv) mutateTransferConfig(cfg invoke.TransferConfig) invoke.TransferConfig {
+	if m.d.dropModeOption {
+		cfg.Mode = nil
+	}
+
+	if m.d.dropSymlinks || m.d.followLies {
+		cfg.Symlinks = invoke.SymlinkSkip
+	}
+
+	if m.d.alwaysSkipSpecial {
+		cfg.SkipSpecial = true
+	}
+
+	if m.d.zeroProgressTotals && cfg.Progress != nil {
+		forward := cfg.Progress
+		cfg.Progress = func(p invoke.TransferProgress) {
+			p.Total = 0
+			forward(p)
+		}
+	}
+
+	return cfg
 }
 
 func (m *misbehaveEnv) mutateStdio(stdio invoke.IO) invoke.IO {
@@ -683,6 +705,8 @@ func defectCatalog() []defectCase {
 		{name: "shallow trees", contract: "transfer/tree-roundtrip-creates-parents", defects: defects{shallowTrees: true}},
 		{name: "shallow empty tree", contract: "transfer/empty-files-and-dirs", defects: defects{shallowTrees: true}},
 		{name: "dropped symlinks", contract: "transfer/symlinks-preserve", defects: defects{dropSymlinks: true}},
+		{name: "unpreserved symlink carried silently", contract: "transfer/symlink-unsupported-errors", defects: defects{stripSymlinkPreserve: true}},
+		{name: "same-path truncates source", contract: "transfer/same-path-preserves-source", defects: defects{destroySamePath: true}},
 		{name: "follow lies on escape", contract: "transfer/follow-rejects-escapes", defects: defects{followLies: true}},
 		{name: "follow lies on content", contract: "transfer/symlink-follow-copies-content", defects: defects{followLies: true}},
 		{name: "forced special skip", contract: "transfer/special-files-error-by-default", defects: defects{alwaysSkipSpecial: true}},
@@ -690,6 +714,7 @@ func defectCatalog() []defectCase {
 		{name: "transfer ignores cancel", contract: "transfer/canceled-before-start-does-nothing", defects: defects{transferIgnoresCancel: true}},
 
 		{name: "pretend TTY", contract: "tty/allocates-terminal", defects: defects{claimTTY: true}},
+		{name: "TTY that keeps stderr apart", contract: "tty/stderr-merges-into-stdout", defects: defects{claimTTY: true}},
 		{name: "silently stripped TTY", contract: "tty/unsupported-errors", defects: defects{stripTTY: true}},
 	}
 }


### PR DESCRIPTION
Three properties the design names but the suite never held providers to. Each has a defect proving it can fail. **One of them found a real docker bug** — see below.

## 1. The undeclared half of the symlink capability

`transfer/symlinks-preserve` checked that a target declaring `SymlinkPreserve` keeps links, but nothing checked what a target *lacking* it must do: **refuse** a tree carrying a link (wrapping `ErrNotSupported`), not drop it and report success — the "silent middle" the capability rule forbids. This is the exact mirror of the two TTY capability halves.

Only a target *without* the capability can exercise it, and every shipped provider declares `SymlinkPreserve` — so no provider runs it directly (it's gated and skips). The `stripSymlinkPreserve` defect stands in for a provider that lacks it. Same structure as `tty/unsupported-errors`.

## 2. The terminal's merged output stream — and a docker bug it found

Ratified decision #3: a TTY has one stream (stderr folded into stdout, the separate `Stderr` writer left untouched), and promised a contract. Only a local unit test carried it.

Pinning it as a contract **turned up a real defect**: the **docker provider captures no command output at all under a requested TTY**. The daemon delivers it — `docker exec -t <c> sh -c 'echo out; echo err 1>&2'` returns `out\r\nerr\r\n` — so the fault is the provider's attach/pump handling, not a daemon limitation (I also ruled out `AttachStdin:true` via the CLI). `tty/allocates-terminal` never caught this because it only checks `test -t 0`'s exit code, never captured output.

It's gated with a **loud `WithKnownGap`** naming the cause, to be fixed separately. **local and ssh pass** — including against a real OpenSSH server, where a genuine pty merges the streams as designed.

## 3. The same-path transfer

The legacy headline bug — `Upload(p, p)` truncating the source while reading it, leaving zero bytes and no error — was tested only for the local provider. `transfer/same-path-preserves-source` now holds every provider to it: where the two sides share a filesystem the overlap guard refuses it; where they cannot alias, atomic delivery keeps the source intact. Either way the file survives. The `destroySamePath` defect reproduces the exact legacy truncation.

## Verification

- Self-test lane green: each contract passes against the reference and fails against its registered defect; the coverage check confirms each has one.
- Passes against **local, fake, ssh** (in-process **and** real OpenSSH). **docker** passes #1 (gated-skip) and #3, and #2 is the known-gap above.
- `just check` green; both integration lanes green.
- A `mutateTransferConfig` helper was extracted from the misbehave `Upload` to keep it under the complexity limit after the new defect — no behavior change.

The docker TTY fix is flagged as a follow-up.