### PR TITLE
fix(docker): Deliver command output under a requested TTY

### DIFF
--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -44,10 +44,7 @@ func TestDockerContractSuite(t *testing.T) {
 
 	invoketest.Verify(t, func(it invoketest.T) invoke.Environment {
 		return dialContainer(asTestingT(it))
-	}, invoketest.WithKnownGap("tty/stderr-merges-into-stdout",
-		"under a requested TTY the provider captures no command output at all, though the daemon "+
-			"delivers it — the docker CLI shows the same command's output — so this is the provider's "+
-			"attach handling, not a daemon limitation; fixed separately"))
+	})
 }
 
 func TestMissingContainerIsNotFound(t *testing.T) {

--- a/docker/process.go
+++ b/docker/process.go
@@ -328,7 +328,14 @@ func (p *process) pumpStdin(stdin io.Reader) {
 		_, _ = io.Copy(p.attach.Conn, stdin)
 	}
 
-	_ = p.attach.CloseWrite()
+	// Half-closing signals end-of-input on a multiplexed stream, but a
+	// terminal is one bidirectional stream: closing its write half tears
+	// the whole connection down, and the command's output with it. Under a
+	// TTY the write side is left to close with the rest of the connection
+	// when the process exits.
+	if !p.tty {
+		_ = p.attach.CloseWrite()
+	}
 }
 
 // pumpOutput demultiplexes the attached stream into the caller's writers.


### PR DESCRIPTION
Fixes the docker bug that #15's stderr-merge contract discovered, and removes the known-gap that gated it.

## Root cause

A command run with a TTY produced **no output at all**. `pumpStdin` half-closes the attached connection once there's nothing left to send:

```go
func (p *process) pumpStdin(stdin io.Reader) {
	if stdin != nil { _, _ = io.Copy(p.attach.Conn, stdin) }
	_ = p.attach.CloseWrite()   // <-- signals stdin-EOF... on a multiplexed stream
}
```

`CloseWrite` is the right way to signal end-of-input on the **multiplexed** stream a non-TTY exec uses. But a TTY exec is **one bidirectional stream**, and half-closing its write side tears the whole connection down — taking the command's still-unread output with it. The daemon had the bytes (the docker CLI shows them for the same command); this side threw them away. That's also why the CLI's `-t -i </dev/null` still captured output — it doesn't half-close.

## The fix

Under a TTY, leave the write half to close with the rest of the connection when the process exits:

```go
	if !p.tty {
		_ = p.attach.CloseWrite()
	}
```

This matches terminal semantics: a session ends when its process exits, not when stdin is half-closed. (A TTY command reading finite piped input no longer gets a stdin-EOF from a closed write half — correct for a terminal, where EOF is Ctrl-D, not a closed descriptor.)

## Verification

Before → after, same command, via the provider:

```
tty  stdout=""                 (bug)
tty  stdout="out\r\nerr\r\n"   (fixed — merged, terminal line endings, separate stderr empty)
```

- The `tty/stderr-merges-into-stdout` contract — added and gated against docker in #15 — now **passes ungated**. That contract is the regression guard; it runs in the docker tagged lane against a live daemon.
- `just check` green; full `-tags docker` lane green (contracts + parity + transfers).