### PR TITLE
fix: Three provider-classification minors

### DIFF
--- a/docker/context.go
+++ b/docker/context.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ruffel/invoke"
 )
@@ -30,10 +31,18 @@ func resolveHost(cfg *Config) (string, error) {
 	// An explicit endpoint is the caller's decision and outranks
 	// everything, as does the environment the docker command reads first.
 	if cfg.Host != "" {
+		if err := checkEndpoint(cfg.Host); err != nil {
+			return "", err
+		}
+
 		return cfg.Host, nil
 	}
 
 	if host := os.Getenv("DOCKER_HOST"); host != "" {
+		if err := checkEndpoint(host); err != nil {
+			return "", err
+		}
+
 		return "", nil
 	}
 
@@ -122,7 +131,25 @@ func contextHost(name string) (string, error) {
 				"pass the endpoint and credentials explicitly: %w", name, invoke.ErrNotSupported)
 	}
 
+	if err := checkEndpoint(meta.Endpoints.Docker.Host); err != nil {
+		return "", fmt.Errorf("docker: context %q: %w", name, err)
+	}
+
 	return meta.Endpoints.Docker.Host, nil
+}
+
+// checkEndpoint refuses a daemon endpoint this provider cannot reach on
+// its own. The docker command reaches an ssh:// daemon through a helper
+// process; without it, connecting fails deep in the client with an error
+// that names the transport rather than the cause, so it is named here.
+func checkEndpoint(host string) error {
+	if strings.HasPrefix(host, "ssh://") {
+		return fmt.Errorf(
+			"docker: endpoint %q uses ssh://, which this provider does not support; "+
+				"expose the daemon over tcp:// or a unix socket instead: %w", host, invoke.ErrNotSupported)
+	}
+
+	return nil
 }
 
 // tlsMaterial reports whether a context stores client certificates.

--- a/docker/context_test.go
+++ b/docker/context_test.go
@@ -154,3 +154,35 @@ func TestResolveHostReportsTLSContextsPlainly(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, invoke.ErrNotSupported)
 }
+
+// TestResolveHostRefusesSSHEndpointsPlainly checks an ssh:// daemon
+// endpoint is named as unsupported however it arrives, rather than
+// deferred to the client to fail on with a transport error.
+//
+//nolint:paralleltest // t.Setenv, which the env route needs, forbids t.Parallel.
+func TestResolveHostRefusesSSHEndpointsPlainly(t *testing.T) {
+	//nolint:paralleltest // t.Setenv forbids t.Parallel.
+	t.Run("explicit host", func(t *testing.T) {
+		_, err := resolveHost(&Config{Host: "ssh://user@host"})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, invoke.ErrNotSupported)
+	})
+
+	//nolint:paralleltest // t.Setenv forbids t.Parallel.
+	t.Run("environment", func(t *testing.T) {
+		t.Setenv("DOCKER_HOST", "ssh://user@host")
+
+		_, err := resolveHost(&Config{})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, invoke.ErrNotSupported)
+	})
+
+	//nolint:paralleltest // t.Setenv forbids t.Parallel.
+	t.Run("context", func(t *testing.T) {
+		writeContext(t, "remote", "remote", "ssh://user@host")
+
+		_, err := resolveHost(&Config{})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, invoke.ErrNotSupported)
+	})
+}

--- a/local/local.go
+++ b/local/local.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"runtime"
@@ -103,7 +104,14 @@ func (e *Environment) LookPath(ctx context.Context, name string) (string, error)
 
 	path, err := exec.LookPath(name)
 	if err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
+		// A bare name missing from PATH reports exec.ErrNotFound; a name
+		// with a separator is looked up as a path, so a missing or
+		// non-executable file reports the filesystem's own error instead.
+		// All of them mean the same thing to a caller: the name did not
+		// resolve to something runnable.
+		if errors.Is(err, exec.ErrNotFound) ||
+			errors.Is(err, fs.ErrNotExist) ||
+			errors.Is(err, fs.ErrPermission) {
 			return "", fmt.Errorf("local: lookpath %q: %w", name, invoke.ErrNotFound)
 		}
 

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -2,6 +2,7 @@ package local_test
 
 import (
 	"io"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -75,6 +76,19 @@ func TestLookPath(t *testing.T) {
 
 	_, err = env.LookPath(t.Context(), "definitely-not-a-real-binary-abc123")
 	assert.ErrorIs(t, err, invoke.ErrNotFound, "LookPath(missing)")
+
+	// A name with a separator is resolved as a path rather than searched
+	// on PATH, and an unresolvable one must classify the same way.
+	_, err = env.LookPath(t.Context(), "./invoke-definitely-not-here")
+	assert.ErrorIs(t, err, invoke.ErrNotFound, "LookPath of a missing relative path")
+
+	// A file that exists but cannot be executed also fails to resolve to
+	// something runnable.
+	notExec := filepath.Join(t.TempDir(), "not-exec")
+	require.NoError(t, os.WriteFile(notExec, []byte("#!/bin/sh\n"), 0o600), "writing non-executable file")
+
+	_, err = env.LookPath(t.Context(), notExec)
+	assert.ErrorIs(t, err, invoke.ErrNotFound, "LookPath of a non-executable file")
 }
 
 // TestTerminationGraceBoundsTheWait checks the configured grace period is

--- a/ssh/files.go
+++ b/ssh/files.go
@@ -469,15 +469,19 @@ func (f sftpFS) Resolve(p string) (string, error) {
 	return resolved, nil
 }
 
-// randomSuffix returns hex material for a name no concurrent command
-// will collide with.
-func randomSuffix() string {
+// randomSuffix returns hex material for a name no concurrent command will
+// collide with.
+//
+// A failure to gather randomness is reported rather than papered over with
+// a fixed string: a predictable name is one an attacker can pre-create, so
+// the caller must fail closed instead of writing to it.
+func randomSuffix() (string, error) {
 	var buf [8]byte
 	if _, err := rand.Read(buf[:]); err != nil {
-		return "fallback"
+		return "", fmt.Errorf("ssh: generating a unique name: %w", err)
 	}
 
-	return hex.EncodeToString(buf[:])
+	return hex.EncodeToString(buf[:]), nil
 }
 
 // splitPath breaks a POSIX path into its components.

--- a/ssh/process.go
+++ b/ssh/process.go
@@ -196,7 +196,12 @@ func (e *Environment) deliverEnv(ctx context.Context, session *ssh.Session, env 
 		return exportPrologue(refused), nil
 	}
 
-	path := "/tmp/.invoke-env-" + randomSuffix()
+	suffix, err := randomSuffix()
+	if err != nil {
+		return "", fmt.Errorf("ssh: start: %w", err)
+	}
+
+	path := "/tmp/.invoke-env-" + suffix
 
 	if err := e.writeRemoteFile(ctx, path, exportScript(refused)); err != nil {
 		return "", fmt.Errorf(


### PR DESCRIPTION
Three small, independent provider fixes, one commit each. All from the audit's minor list — mechanical, no behavior decisions.

## `fix(local)` — an unresolvable path is `ErrNotFound`

`LookPath` promises a name it cannot resolve wraps `ErrNotFound`. That held only for a bare name searched on PATH (`exec.ErrNotFound`). A name *with a separator* is looked up as a path, so a missing or non-executable file returned the filesystem's own error unwrapped — and a caller branching on `ErrNotFound` couldn't recognize it.

Now `fs.ErrNotExist` and `fs.ErrPermission` (missing / non-executable path) classify the same as a PATH miss. Tested: `./missing` and a non-executable file both wrap `ErrNotFound`.

## `fix(ssh)` — fail closed on a name it can't randomize

The out-of-band env file is named with random material; on a randomness failure the name fell back to the fixed string `"fallback"`. A predictable name is one an attacker can pre-create — the file the secrets are written to could be theirs or a symlink elsewhere. It now reports the failure and the start fails, matching what the transfer engine already does. (The `crypto/rand` failure path can't be triggered on demand, so this is a defensive change with no test — consistent with the engine's existing fail-closed.)

## `fix(docker)` — name an `ssh://` endpoint plainly

An `ssh://` daemon endpoint (which needs a helper process this provider doesn't run) was passed to the client and failed deep in a dial with a transport error, not a cause — the opacity the TLS-context path already avoids. Now refused wrapping `ErrNotSupported` however it arrives (explicit host, `DOCKER_HOST`, or a context's stored endpoint), naming the scheme. Tested across all three routes (daemon-free).

## Verification

- `just check` green; both integration lanes green (real OpenSSH exercises the env-file path; docker lane unaffected but confirmed).
- New tests: local LookPath separator/non-exec cases; docker `ssh://` across all three resolution routes.