### PR TITLE
docs: Signal delivery honesty — what SSH cannot confirm, and which processes a signal reaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,22 @@ capability must work, and an undeclared one must fail with
 | Capability | local | ssh | docker | fake |
 |-------------------|:-----:|:---:|:------:|:----:|
 | `TTY`             | yes   | yes | yes    | no   |
-| `Signals`         | yes   | yes | yes¹   | yes  |
+| `Signals`         | yes   | yes² | yes¹   | yes  |
 | `SymlinkPreserve` | yes   | yes | yes    | yes  |
 
 ¹ A container must have a shell for a signal to reach the right process.
 Without one the capability is not declared.
+
+² SSH carries the signal but offers no confirmation, so a server that
+discards it cannot be told from one that acted. The servers this is
+tested against — a real OpenSSH server, and the in-process one — honor
+it. For any other, run `invoketest` against it and the signal contracts
+will answer.
+
+A signal always reaches the process. Whether it reaches that process's
+children depends on the target: local runs commands in their own process
+group and signals the group, as a terminal does; ssh and docker address
+the single process.
 
 ## Things worth knowing
 

--- a/doc.go
+++ b/doc.go
@@ -65,7 +65,11 @@
 //   - TTY — allocated by every target that runs real processes.
 //   - Signals — delivered by every target, though a container must have a
 //     shell for one to reach the right process; without a shell the
-//     capability is not declared. The docker package documents why.
+//     capability is not declared. The docker package documents why, and
+//     the ssh package documents the one thing its protocol will not
+//     confirm. A signal always reaches the process it names; whether it
+//     also reaches that process's children is a property of the target,
+//     described on [Process.Signal].
 //   - SymlinkPreserve — honored by every target.
 //
 // # Testing

--- a/interfaces.go
+++ b/interfaces.go
@@ -64,6 +64,14 @@ type Process interface {
 	// Signal delivers sig to the process. It either delivers the signal
 	// or returns an error (wrapping [ErrNotSupported] when the target
 	// cannot deliver it); it never silently does nothing.
+	//
+	// What reaches the process is guaranteed. What reaches its children
+	// is not, and targets differ: one that runs the command in a process
+	// group of its own signals the whole group, which is what a terminal
+	// does and what the local machine therefore does; one that can only
+	// address a single process signals that one alone. Code that needs a
+	// command's children to receive a signal should send it to them
+	// rather than rely on which kind of target it is talking to.
 	Signal(sig Signal) error
 
 	// Close releases the handle, terminating the process if it is still

--- a/ssh/environment.go
+++ b/ssh/environment.go
@@ -180,11 +180,24 @@ func (e *Environment) OS() invoke.TargetOS {
 	return e.os
 }
 
-// Capabilities reports the SSH target's optional features. Signal
-// delivery and symlink-preserving transfers are supported.
+// Capabilities reports the SSH target's optional features. Terminal
+// allocation is available, the protocol carrying a pseudo-terminal
+// request natively, and SFTP preserves symbolic links.
 //
-// Terminal allocation is available: the protocol carries a pseudo-
-// terminal request natively.
+// Signal delivery is declared with a caveat this provider cannot resolve
+// for itself. The protocol carries a signal request, and the servers this
+// library is tested against act on it — a real OpenSSH server and the
+// in-process one, both of which the signal contracts run against. But the
+// request is sent without asking for a reply, there being no answer worth
+// waiting for, so a server that discards it cannot be told apart from one
+// that obeyed. A container can be asked whether it holds a shell, which
+// is why the docker provider conditions this capability on the answer; a
+// server offers nothing equivalent to ask.
+//
+// A server not known to honor signals can be put to the question
+// directly: run invoketest.Verify against it and the signal contracts
+// report what it actually does, once, rather than every connection
+// paying for a guess.
 func (e *Environment) Capabilities() invoke.Capabilities {
 	return invoke.Capabilities{
 		TTY:             true,


### PR DESCRIPTION
Two documentation gaps around signal delivery. No code changes.

## `docs(ssh)` — say what the protocol will not confirm

The ssh provider declares `Signals: true` unconditionally, which the capability rule reads as "demonstrably works." The protocol carries a signal request and the servers this is tested against act on it — a real OpenSSH server and the in-process one, both of which the signal contracts run against — but the request is sent with `wantReply=false`, so **a server that discards it cannot be told from one that obeyed**.

Notably, the docker provider *does* condition the same capability (`Signals: e.hasShell`), because a container can be asked whether it holds a shell. A server offers nothing equivalent, and only a behavioural probe — start a process, signal it, watch it die — could answer, at a cost paid on every connection to settle a question most callers already know the answer to.

So the caveat is stated, with the honest way to resolve it for a specific server: **run `invoketest.Verify` against it once**, and the signal contracts report what it actually does. That's the suite's stated purpose, and it's a development-time answer rather than a runtime guess.

## `docs` — say which processes a signal reaches

A signal reaches the process it names on every target. Whether it *also* reaches that process's children is where the targets diverge: **local** runs a command in its own process group and signals the group (terminal semantics, deliberately); **ssh** and **docker** address the single process. Nothing documented this, and it's visible to anyone whose command spawns children.

`Process.Signal`, the package overview, and the README capability table now say so.

## A note on scope

I'd sketched this as "a contract plus docs." On inspection **the contract already exists**: `lifecycle/signal-terminates-process` pins the floor — the signalled process dies with the signal recorded, on every target declaring the capability. A second contract would only restate it. What was missing is the part *above* the floor, which callers must not assume in either direction, and that is documentation. So this is docs-only, deliberately.

## Verification

`just check` green (godoc lint included; the `[Process.Signal]` reference resolves).