### PR TITLE
test(ssh): Let a terminal's output arrive before the exit closes it

### DIFF
--- a/ssh/testserver_test.go
+++ b/ssh/testserver_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/creack/pty"
 	"github.com/pkg/sftp"
@@ -407,6 +408,11 @@ func runExec(channel ssh.Channel, state *sessionState, command string) {
 	reportExit(channel, cmd.Wait())
 }
 
+// ptyDrainGrace bounds the wait for a terminal's output to reach the
+// channel after the command has exited, so a descendant still holding the
+// terminal open cannot stall the session for good.
+const ptyDrainGrace = 2 * time.Second
+
 // runExecWithPTY runs the command attached to a real pseudo-terminal, so
 // a command asking whether it has one gets a truthful answer.
 func runExecWithPTY(channel ssh.Channel, state *sessionState, cmd *exec.Cmd) {
@@ -422,9 +428,27 @@ func runExecWithPTY(channel ssh.Channel, state *sessionState, cmd *exec.Cmd) {
 	state.setCmd(cmd)
 
 	go func() { _, _ = io.Copy(master, channel) }()
-	go func() { _, _ = io.Copy(channel, master) }()
 
-	reportExit(channel, cmd.Wait())
+	drained := make(chan struct{})
+
+	go func() {
+		defer close(drained)
+
+		_, _ = io.Copy(channel, master)
+	}()
+
+	waitErr := cmd.Wait()
+
+	// The terminal's output has to arrive before the exit status closes
+	// the channel, or the command's last words are thrown away — which a
+	// real server does not do. Reading the terminal ends when the command
+	// releases it, which exiting does.
+	select {
+	case <-drained:
+	case <-time.After(ptyDrainGrace):
+	}
+
+	reportExit(channel, waitErr)
 }
 
 // reportExit sends the SSH exit-status or exit-signal for a finished


### PR DESCRIPTION
Fixes the CI failure of `tty/stderr-merges-into-stdout` on the ssh unit lane.

## Diagnosis

The contract is correct and the provider is correct. The fault is in the **in-process test server**.

`runExecWithPTY` reported the exit the moment `cmd.Wait()` returned — and `reportExit` does `defer channel.Close()`, with a deferred `master.Close()` behind it — while a goroutine was still copying the terminal's buffered output to the channel. Whichever won the race decided whether the command's output survived.

On a quiet macOS machine the copy won, which is why it passed locally and in the `-tags openssh` lane. On a loaded Linux runner under `-race` the close usually won, so the contract saw **no output at all** — the `"" does not contain "out"` in the CI log.

A real OpenSSH server drains the terminal before closing the channel; the server the contracts are checked against did not.

## Fix

Wait for the terminal to drain before reporting the exit, bounded (2s) so a descendant still holding the terminal open cannot stall the session for good.

## Verification — reproduced first, then fixed

I reproduced it on Linux in a container before changing anything (it is intermittent — one 40-run pass came back clean, the next failed):

| | before | after |
|---|---|---|
| Contract, Linux, `-race`, 40 runs | **FAIL** | — |
| Contract, Linux, `-race`, 120 runs | — | clean |
| Full `./ssh/` package, Linux, ×3 | — | clean |
| `just check`, `-tags openssh` lane | — | green |

### One thing worth knowing for future Linux runs

Running the suite **as root** in a container fails `transfer/failure-preserves-destination` — the contract makes a source unreadable with `chmod 000`, which root can read anyway, so the upload succeeds when the contract expects it to fail. That is pre-existing, unrelated to this change, and does not affect CI (which runs non-root). All the results above were taken as a non-root user to match CI; I mention it because it will bite anyone else who reproduces in a root container.