### PR TITLE
fix(fake): Refuse a script the shell cannot run, rather than run it wrongly

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ command that flushes something substantial on the way out.
 mock: it passes the same contract suite the real providers do, so a test
 written against it cannot come to rely on behavior no real target has.
 
+Its shell interprets a subset — sequencing, quoting, `$NAME`, `$(...)`,
+redirection to `/dev/null` and between the output streams — and refuses
+what it cannot run, naming it, rather than running it wrongly. A pipeline
+or a `||` list fails with `ErrNotSupported` instead of quietly becoming
+arguments to the first command. Script anything beyond the subset with
+`Handle`, or run it against a real target.
+
 ```go
 env := fake.New()
 env.Handle("systemctl", func(_ context.Context, cmd invoke.Command, s *fake.Session) int {

--- a/fake/fake.go
+++ b/fake/fake.go
@@ -13,6 +13,32 @@
 // vocabulary; commands that are neither registered nor builtin fail with
 // [invoke.ErrNotFound], exactly as a missing binary does on a real
 // target.
+//
+// # What the shell runs
+//
+// [invoke.Shell] scripts are interpreted, not executed, and the
+// interpreter covers a subset: sequencing with ; and &&, single and
+// double quotes, $NAME expansion, $(command) substitution, redirection to
+// /dev/null and between the two output streams, cd, and exit.
+//
+// A script reaching outside that subset is refused — wrapping
+// [invoke.ErrNotSupported], before any process exists — rather than run
+// wrongly. Pipelines, || lists, redirection to a file, input redirection,
+// backquotes, newline-separated commands, background commands, and the
+// special and positional parameters ($?, $1, $$) are all refused by name.
+// The alternative was worse than useless: an unrecognized character is
+// just another character to a tokenizer, so a pipeline used to become
+// arguments to the first command and `false || echo rescued` exited 1
+// having printed nothing, where every real target exits 0 having printed.
+// A test asserting that is not merely unverified — it asserts the
+// opposite of the truth.
+//
+// The builtins are likewise a vocabulary rather than an implementation:
+// they cover the options the contract suite and ordinary shell-outs use.
+// Notably cat reads standard input and ignores file arguments, echo takes
+// no flags, and test and cd do not follow symbolic links. A script
+// needing more than the subset belongs in a handler registered with
+// [Environment.Handle], or on a real target.
 package fake
 
 import (
@@ -140,6 +166,15 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 	handler, builtin := e.resolve(cmd.Path)
 	if handler == nil && !builtin {
 		return nil, fmt.Errorf("fake: start %q: %w", cmd.Path, invoke.ErrNotFound)
+	}
+
+	// Refused before the process exists, so it cannot be mistaken for the
+	// command running and failing. A script the shell cannot run is a
+	// thing this target cannot do, not a verdict about the script.
+	if handler == nil {
+		if err := shellScriptSupported(cmd); err != nil {
+			return nil, err
+		}
 	}
 
 	e.record(cmd)

--- a/fake/fake_test.go
+++ b/fake/fake_test.go
@@ -173,3 +173,60 @@ func TestUnknownCommandIsNotFound(t *testing.T) {
 	_, err := env.Start(t.Context(), invoke.New("unscripted-command"), invoke.IO{})
 	assert.ErrorIs(t, err, invoke.ErrNotFound)
 }
+
+// TestUnsupportedShellSyntaxIsRefusedNotRun pins the shape of the
+// refusal, which matters as much as the refusal itself.
+//
+// A script the fake shell cannot run is refused before a process exists,
+// wrapping ErrNotSupported. Reporting it as a command that ran and failed
+// would satisfy a caller asserting failure — and such a caller is exactly
+// the one being misled, since `false || echo rescued` exits zero on every
+// real target.
+func TestUnsupportedShellSyntaxIsRefusedNotRun(t *testing.T) {
+	t.Parallel()
+
+	env := fake.New()
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	proc, err := env.Start(t.Context(), invoke.Shell("false || echo rescued"), invoke.IO{})
+	if err == nil {
+		_ = proc.Close()
+
+		require.Fail(t, "a script the fake shell cannot run reported success")
+	}
+
+	assert.ErrorIs(t, err, invoke.ErrNotSupported,
+		"an unrunnable script is a thing this target cannot do")
+
+	var exitErr *invoke.ExitError
+
+	assert.NotErrorAs(t, err, &exitErr,
+		"refusing a script must not look like the script running and failing")
+
+	assert.Contains(t, err.Error(), "||", "the refusal must name what it could not run")
+}
+
+// TestUnsupportedSyntaxNestedInQuotesIsRefusedLoudly covers the script
+// the check at Start cannot see: quoted, and so opaque until it runs.
+func TestUnsupportedSyntaxNestedInQuotesIsRefusedLoudly(t *testing.T) {
+	t.Parallel()
+
+	env := fake.New()
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	var stdout, stderr bytes.Buffer
+
+	proc, err := env.Start(t.Context(),
+		invoke.Shell(`sh -c 'echo hi | tr h H'`), invoke.IO{Stdout: &stdout, Stderr: &stderr})
+	require.NoError(t, err, "the outer script is within the subset")
+
+	result, waitErr := proc.Wait()
+	require.Error(t, waitErr, "a nested script the shell cannot run must not report success")
+
+	assert.NotEqual(t, 0, result.ExitCode)
+	assert.Contains(t, stderr.String(), "not simulated",
+		"the failure must say what the shell could not run")
+	assert.Empty(t, stdout.String(), "nothing must be produced by a script that did not run")
+}

--- a/fake/shell.go
+++ b/fake/shell.go
@@ -3,17 +3,187 @@ package fake
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
+	"unicode"
+
+	"github.com/ruffel/invoke"
 )
 
 // The mini-shell interprets the POSIX subset the contract suite and
 // typical incidental scripts use: command sequencing with ; and &&,
 // single and double quotes, $VAR expansion, $(command) substitution,
 // numeric redirects to /dev/null and between the two output streams, cd,
-// and exit. Nothing more — a script needing more belongs in a consumer
-// handler.
+// and exit.
+//
+// Nothing more, and the boundary is enforced rather than described: a
+// script reaching past the subset is refused by name, because the
+// alternative is a tokenizer treating what it does not recognize as
+// ordinary text and answering wrongly without saying so. A script needing
+// more belongs in a consumer handler.
+
+// shellScriptSupported refuses a shell command whose script uses a
+// construct this shell cannot run, naming it and wrapping
+// [invoke.ErrNotSupported].
+//
+// The refusal is deliberately not an exit status. A caller asserting that
+// a command failed would be satisfied by one, and the whole reason to
+// refuse is that such a caller is being told something untrue.
+func shellScriptSupported(cmd invoke.Command) error {
+	if cmd.Path != "sh" || len(cmd.Args) < 2 || cmd.Args[0] != "-c" {
+		return nil
+	}
+
+	if err := unsupportedSyntax(cmd.Args[1]); err != nil {
+		return fmt.Errorf(
+			"fake: start: the fake shell does not simulate %s; script it with Handle, "+
+				"or run it against a real target: %w", err, invoke.ErrNotSupported)
+	}
+
+	return nil
+}
+
+// exitUnsupportedSyntax is the status a nested script gets when it uses a
+// construct the shell cannot run. It sits above the range a simulated
+// command would return, so it is not mistaken for one.
+const exitUnsupportedSyntax = 93
+
+// unsupportedSyntax reports the first construct a script uses that this
+// shell does not implement, or nil when the script is within the subset.
+//
+// What falls outside the subset used to be taken literally, because an
+// unrecognized character is just another character to a tokenizer: a
+// pipeline became arguments to the first command, a redirection became
+// two more words, and `false || echo rescued` exited 1 having printed
+// nothing where a real shell exits 0 having printed. A test written
+// against that is not merely unverified — it can assert the opposite of
+// what every real target does — so a script this shell cannot run is
+// refused rather than run wrongly.
+//
+//nolint:cyclop,gocognit // One pass over the script; the cases read better together than split.
+func unsupportedSyntax(script string) error {
+	runes := []rune(script)
+
+	inSingle, inDouble := false, false
+	wordStart := 0
+
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+
+		if inSingle {
+			if r == '\'' {
+				inSingle = false
+			}
+
+			continue
+		}
+
+		if inDouble {
+			switch r {
+			case '"':
+				inDouble = false
+			case '$':
+				if err := unsupportedParameter(runes, i); err != nil {
+					return err
+				}
+			}
+
+			continue
+		}
+
+		switch r {
+		case '\'':
+			inSingle = true
+		case '"':
+			inDouble = true
+		case ' ', '\t':
+			wordStart = i + 1
+		case '\n':
+			// A newline that only trails the script separates nothing.
+			if strings.TrimSpace(string(runes[i:])) != "" {
+				return errors.New("a newline separating commands")
+			}
+		case '|':
+			if i+1 < len(runes) && runes[i+1] == '|' {
+				return fmt.Errorf("an %q list", "||")
+			}
+
+			return fmt.Errorf("a %q pipeline", "|")
+		case '<':
+			return errors.New("input redirection")
+		case '`':
+			return errors.New("backquote substitution")
+		case '&':
+			if i+1 < len(runes) && runes[i+1] == '&' {
+				i++
+
+				continue
+			}
+
+			return errors.New("a background command")
+		case '>':
+			end := wordEnd(runes, i)
+
+			word := string(runes[wordStart:end])
+			if _, ok := parseRedirect(word); !ok {
+				return fmt.Errorf("the redirection %q", word)
+			}
+
+			i = end - 1
+		case '$':
+			if err := unsupportedParameter(runes, i); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// unsupportedParameter reports a parameter form the shell expands to
+// nothing useful. $NAME and $(command) are interpreted; the special and
+// positional parameters are not, and would otherwise survive as the
+// literal text a caller wrote.
+func unsupportedParameter(runes []rune, at int) error {
+	next := at + 1
+	if next >= len(runes) {
+		return nil
+	}
+
+	r := runes[next]
+
+	if r == '(' || r == '_' || unicode.IsLetter(r) {
+		return nil
+	}
+
+	if unicode.IsDigit(r) || strings.ContainsRune("?$!#@*", r) {
+		return fmt.Errorf("the parameter %q", "$"+string(r))
+	}
+
+	// A $ before anything else is an ordinary character to a real shell
+	// too, so it is left alone.
+	return nil
+}
+
+// wordEnd returns the index just past the word containing position at.
+//
+// A word ends at whitespace or at whatever separates commands, so a
+// redirection written flush against the next one — "2>/dev/null; cmd" —
+// is read as the redirection it is. An ampersand does not end it: the
+// duplicating forms, ">&2" and "2>&1", contain one.
+func wordEnd(runes []rune, at int) int {
+	for i := at; i < len(runes); i++ {
+		switch runes[i] {
+		case ' ', '\t', '\n', ';', '|', ')':
+			return i
+		}
+	}
+
+	return len(runes)
+}
 
 // step is one simple command in a script, with its connector to the
 // previous step.
@@ -23,7 +193,18 @@ type step struct {
 }
 
 // execScript runs a shell script within the session.
+//
+// A script reaching here has usually been checked at Start, where a
+// construct this shell cannot run is refused outright. One nested inside
+// quotes — `sh -c 'a | b'` — is opaque until it runs, so it is checked
+// again here and refused loudly rather than mis-run.
 func execScript(ctx context.Context, s *session, script string) (int, bool) {
+	if err := unsupportedSyntax(script); err != nil {
+		_, _ = io.WriteString(s.stderr, "sh: "+err.Error()+" is not simulated by the fake shell\n")
+
+		return exitUnsupportedSyntax, false
+	}
+
 	steps, ok := splitScript(script)
 	if !ok {
 		_, _ = io.WriteString(s.stderr, "sh: syntax error\n")

--- a/fake/shell_internal_test.go
+++ b/fake/shell_internal_test.go
@@ -1,0 +1,82 @@
+package fake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSupportedScriptsAreAccepted pins the subset the shell does run.
+//
+// Every one of these is either used by the contract suite or is the
+// ordinary way to write something the shell interprets, so a check that
+// refused any of them would have made the fake useless rather than
+// honest.
+func TestSupportedScriptsAreAccepted(t *testing.T) {
+	t.Parallel()
+
+	scripts := []string{
+		"echo hi",
+		"echo out; echo err 1>&2",
+		"echo to-stderr >&2",
+		"dd if=/dev/zero bs=1024 count=256 2>/dev/null; dd if=/dev/zero bs=1024 count=64 1>&2 2>/dev/null",
+		`printf '%s|%s' "$HOME" "$INVOKE_DUP"`,
+		`test -n "$(find /x -maxdepth 0 -perm 0644)"`,
+		"sleep 1 && touch /marker",
+		"cd /tmp",
+		"echo $HOME",
+		"exit 3",
+		// A metacharacter inside quotes is data, not syntax.
+		"echo 'a | b'",
+		`echo "a > b"`,
+		`echo 'back ` + "`" + `tick'`,
+		// A newline that only trails the script separates nothing.
+		"echo hi\n",
+	}
+
+	for _, script := range scripts {
+		assert.NoErrorf(t, unsupportedSyntax(script), "script must be accepted: %q", script)
+	}
+}
+
+// TestUnsupportedScriptsAreRefused pins the constructs the shell cannot
+// run and used to take literally instead.
+//
+// Each of these produced a wrong answer silently: the pipeline became
+// arguments, the redirection became words, and the || list inverted —
+// exiting non-zero having printed nothing where a real shell exits zero
+// having printed.
+func TestUnsupportedScriptsAreRefused(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		script string
+		names  string
+	}{
+		{name: "pipeline", script: "echo hi | tr h H", names: "pipeline"},
+		{name: "or list", script: "false || echo rescued", names: "||"},
+		{name: "redirect to a file", script: "echo data > /tmp/f.txt", names: "redirection"},
+		{name: "redirect to a named file", script: "echo data >/tmp/f.txt", names: "redirection"},
+		{name: "input redirect", script: "cat < /etc/hosts", names: "input redirection"},
+		{name: "newline separator", script: "echo a\necho b", names: "newline"},
+		{name: "status parameter", script: "false; echo $?", names: "$?"},
+		{name: "positional parameter", script: "echo $1", names: "$1"},
+		{name: "pid parameter", script: "echo $$", names: "$$"},
+		{name: "background", script: "sleep 30 & echo started", names: "background"},
+		{name: "backquote", script: "echo `date`", names: "backquote"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := unsupportedSyntax(tt.script)
+			require.Errorf(t, err, "script must be refused: %q", tt.script)
+
+			assert.Containsf(t, err.Error(), tt.names,
+				"the refusal must name what it could not run, for %q", tt.script)
+		})
+	}
+}


### PR DESCRIPTION
**Breaking for some fake-based tests — deliberately.** See the last section.

## The problem

The fake's shell interprets a subset of `sh`, and everything outside it was taken **literally** — an unrecognized character is just another character to a tokenizer. So:

| script | fake did | a real target does |
|---|---|---|
| `echo hi \| tr h H` | printed `hi \| tr h H`, exit 0 | printed `Hi` |
| `echo data > /tmp/f` | printed `data > /tmp/f` | wrote the file |
| `false \|\| echo rescued` | **exit 1, printed nothing** | **exit 0, printed `rescued`** |
| `false; echo $?` | printed `$?` | printed `1` |
| `cat < /etc/hosts` | ignored the redirect | read the file |

The third row is the one that matters most: a test asserting that command failed **passes against the fake and asserts the opposite of the truth**. That falsifies the fake's whole reason to exist — offered as a target a test "cannot come to rely on behavior no real target has", while delivering exactly such behavior, silently.

## The fix

A script reaching outside the subset is refused, by name.

**At `Start` the refusal wraps `ErrNotSupported`, before any process exists.** That shape matters as much as refusing at all: reported as a command that *ran and failed*, it would satisfy the very caller being misled. It is not an exit status, so it cannot be mistaken for one.

A script hidden inside quotes (`sh -c 'a | b'`) is opaque until it runs, so the shell checks again at execution and fails loudly with a diagnostic on stderr.

Refused: pipelines, `||` lists, redirection to a file, input redirection, backquotes, newline-separated commands, background commands, and the special/positional parameters (`$?`, `$1`, `$$`).

## What still runs is unchanged, and pinned

The accepted subset — sequencing, quoting, `$NAME`, `$(...)`, `/dev/null` and stream-duplicating redirects, `cd`, `exit` — is unchanged and now has its own test, including the cases that make the check non-trivial:

- **metacharacters that are data, not syntax**: the contract suite's own `printf '%s|%s' "$HOME" "$X"` has a pipe *inside quotes* and must stay legal;
- **a redirection flush against the next command**: `dd ... 2>/dev/null; dd ...` — my first attempt swallowed the `;` into the redirect word and broke a contract, which is how I found it;
- `>&2` and `2>&1`, whose `&` must *not* end the word even though a bare `&` is refused.

## Verification

- 14 accepted scripts and 11 refused constructs, table-tested.
- End-to-end: the refusal is `ErrNotSupported` and **explicitly not** an `ExitError`; the nested-in-quotes case fails loudly with nothing on stdout.
- Full contract suite still passes against the fake; `just check` and the OpenSSH lane green.

## Breaking change

Any test passing on a script the fake never really ran will now fail. **That is the point** — it was asserting something no target does. Worth a minor bump and a release note.

Also documented: the builtin vocabulary is a vocabulary, not an implementation (`cat` reads stdin and ignores file arguments, `echo` takes no flags, `test`/`cd` do not follow symlinks). Those are stated in the package doc rather than enforced — they produce a wrong answer to a narrower question, and are worth a separate look if you want them closed too.