### PR TITLE
ci: Draft the release notes as the changes land

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,83 @@
+# Release Drafter keeps a draft release current as pull requests merge, so
+# cutting a release is publishing something already written rather than
+# recalling what changed.
+#
+# The draft is a starting point rather than the finished notes. It groups by
+# the kind of change, and a release worth reading usually groups by theme
+# and says why each change mattered; v0.4.0's notes did, and no generator
+# would have produced them. Edit before publishing.
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: 'Breaking changes'
+    labels: ['breaking']
+  - title: 'Security'
+    labels: ['security']
+  - title: 'Features'
+    labels: ['feature']
+  - title: 'Fixes'
+    labels: ['fix']
+  - title: 'Contracts and tests'
+    labels: ['test']
+  - title: 'Documentation'
+    labels: ['documentation']
+  - title: 'Build and CI'
+    labels: ['chore']
+
+change-template: '- $TITLE (#$NUMBER)'
+
+# A title carrying markdown of its own would otherwise render as markdown.
+change-title-escapes: '\<*_&'
+
+# Pre-1.0, a breaking change raises the minor rather than the major. No
+# major bucket is listed on purpose: leaving one would let an ordinary
+# release resolve to v1.0.0, which is a decision to take deliberately and
+# not one to arrive at by labelling.
+version-resolver:
+  minor:
+    labels:
+      - 'breaking'
+      - 'feature'
+  patch:
+    labels:
+      - 'security'
+      - 'fix'
+      - 'test'
+      - 'documentation'
+      - 'chore'
+  default: patch
+
+# Labels are read from the pull request title, which this repository writes
+# as a Conventional Commit. Labelling was the step the previous setup
+# omitted, and without it every release resolved to a patch however much had
+# changed.
+#
+# Note what the breaking rule requires: the Conventional Commits "!" marker,
+# as in "fix(fake)!: ...". This repository has not used it — v0.4.0's
+# breaking change was titled "fix(fake): ..." — so either that convention is
+# adopted or the "breaking" label is applied by hand. Left as it is, a
+# breaking change is drafted as a patch, which is the previous failure in a
+# new form.
+autolabeler:
+  - label: 'breaking'
+    title: '/^\w+(\(.+\))?!:/'
+  - label: 'feature'
+    title: '/^feat(\(.+\))?!?:/'
+  - label: 'fix'
+    title: '/^fix(\(.+\))?!?:/'
+  - label: 'test'
+    title: '/^test(\(.+\))?!?:/'
+  - label: 'documentation'
+    title: '/^docs(\(.+\))?!?:/'
+  - label: 'chore'
+    title: '/^(build|ci|refactor|chore|style|perf)(\(.+\))?!?:/'
+
+exclude-labels:
+  - 'skip-changelog'
+
+template: |
+  $CHANGES
+
+  **Full changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -54,12 +54,11 @@ version-resolver:
 # omitted, and without it every release resolved to a patch however much had
 # changed.
 #
-# Note what the breaking rule requires: the Conventional Commits "!" marker,
-# as in "fix(fake)!: ...". This repository has not used it — v0.4.0's
-# breaking change was titled "fix(fake): ..." — so either that convention is
-# adopted or the "breaking" label is applied by hand. Left as it is, a
-# breaking change is drafted as a patch, which is the previous failure in a
-# new form.
+# A breaking change carries the Conventional Commits "!" marker, as in
+# "fix(fake)!: ...". That is what the rule below matches, and it is the only
+# thing that raises the minor: a breaking change titled without it drafts as
+# a patch, which is the previous failure in a new form. The convention is
+# stated in the README, under Development.
 autolabeler:
   - label: 'breaking'
     title: '/^\w+(\(.+\))?!:/'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,38 @@
+# Keeps a draft release current as pull requests merge. The configuration
+# lives in .github/release-drafter.yml.
+name: Release drafter
+
+# Drafting runs on main rather than on a tag. This repository tags two
+# modules together — vX.Y.Z and docker/vX.Y.Z — and drafting per tag would
+# raise a second, duplicate draft for the submodule. Keeping the draft
+# current on main means the notes already exist when the tag is pushed.
+on:
+  push:
+    branches: [main]
+  # Labels a pull request as it arrives or is retitled, which is what both
+  # the categories and the version resolution read. A pull request from a
+  # fork carries a read-only token, so its labels have to be applied by
+  # hand; pull_request_target would fix that by running with write access
+  # against code from the fork, which is not a trade worth making.
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  draft:
+    name: Update the draft release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write # Write the draft release.
+      pull-requests: write # Apply labels.
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,5 +1,12 @@
 # Keeps a draft release current as pull requests merge. The configuration
 # lives in .github/release-drafter.yml.
+#
+# That configuration is read from the default branch, always — never from
+# the branch being built. So this fails with "Configuration file ... is not
+# found" on the pull request that introduces it, and on any later one that
+# only edits it: what runs is whatever main already holds. A change to the
+# configuration is therefore proved by the run after it merges, not by the
+# run on its own pull request.
 name: Release drafter
 
 # Drafting runs on main rather than on a tag. This repository tags two

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ The integration lanes run the suite against a real OpenSSH server and a
 real container, and compare the providers against each other. They need a
 container runtime, so they are not part of `just check`.
 
+Commits and pull request titles are [Conventional
+Commits](https://www.conventionalcommits.org): `fix(ssh): ...`,
+`test(invoketest): ...`, one reviewable concern each. A change that breaks
+callers carries the `!` marker — `fix(fake)!: ...` — which is what tells
+the release draft to raise the minor rather than the patch. Pre-1.0 a
+breaking change is a minor; nothing here resolves to a major.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Keeps a draft release current as PRs merge, so cutting a release is publishing something already written rather than reconstructing it from the log.

## What it does

- `.github/release-drafter.yml` — categories, version resolution, autolabeling
- `.github/workflows/release-drafter.yml` — runs on push to `main` and on PR events

Labels drive both the categories and the version, and the labels come from the PR title, which this repo already writes as a Conventional Commit.

## Three decisions the stock configuration gets wrong here

**1. No `major` bucket.** Pre-1.0, a breaking change raises the *minor*. A stock resolver maps breaking → major and would have offered **v1.0.0** for this release. Omitted deliberately, so reaching 1.0 stays a decision rather than something arrived at by labelling.

**2. Drafts on `main`, not on tags.** This repo tags two modules together (`v0.4.0` **and** `docker/v0.4.0`); drafting per tag would raise a second, duplicate draft for the submodule. Running on `main` sidesteps it — the notes exist by the time you tag.

**3. Autolabeling is the point.** The previous setup omitted it, so every release resolved to a patch. Verified the regexes against this release's real titles:

| PR title | labels | resolves |
|---|---|---|
| `fix(fake): Refuse a script the shell cannot run` | `fix` | patch |
| `test(ssh): Let a terminal's output arrive…` | `test` | patch |
| `fix(ssh, local): Refuse to start a process…` | `fix` | patch |
| `build(deps): Bump actions/setup-go…` | `chore` | patch |
| `feat(local): Allocate a terminal on request` | `feature` | **minor** |
| `fix(fake)!: Refuse a script…` | `breaking`,`fix` | **minor** |

## The caveat that needs your decision

Look at the first and last rows. **v0.4.0's breaking change was titled `fix(fake):` without the `!`**, so it would have labelled `fix` and drafted as a **patch** — the previous failure in a new form.

So one of these has to happen, and I can't pick for you:

- adopt the Conventional Commits `!` marker for breaking titles (`fix(fake)!: …`), or
- apply the `breaking` label by hand when it applies.

It's documented in the config next to the rule so it isn't rediscovered later.

## Notes

- Fork PRs carry a read-only token, so their labels need applying by hand. `pull_request_target` would fix that by running with write access against fork code — not a trade worth making, and noted in the workflow.
- Action tag-pinned (`@v6`) to match `actions/checkout@v7` and `setup-go@v6` here; SHA-pinning would be a separate, repo-wide change.
- `timeout-minutes` and `concurrency` set, matching the other workflows.
- No Go code touched; both files validated as YAML.

The draft is a starting point, not the artifact — it groups by kind of change, whereas v0.4.0's notes group by theme and explain why each mattered. Expect to edit before publishing.