### PR TITLE
build: Cover the docker submodule in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,23 @@ updates:
       go-dependencies:
         patterns: ["*"]
 
+  # The docker submodule is its own Go module, so it needs its own entry:
+  # the root directory above covers only the core module's go.mod, which is
+  # why the submodule's dependencies raised alerts but never an update.
+  - package-ecosystem: gomod
+    directory: /docker
+    schedule:
+      interval: weekly
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+    ignore:
+      # The core module is pinned to a released version by hand and
+      # repointed only at release time (see RELEASING.md). An automated
+      # bump here would propose a version that does not exist yet and
+      # collide with that process.
+      - dependency-name: "github.com/ruffel/invoke"
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,5 +37,13 @@ are worth stating, because they shape what counts as a vulnerability:
   it.** A file transfer must not let a hostile target write outside the
   destination the caller chose, and an interrupted command must not be
   reported as one that certainly ran. Failures of that kind are in scope.
+- **The Docker daemon is trusted infrastructure.** The docker provider is
+  a client of a daemon the caller chose to talk to; a vulnerability in the
+  daemon itself is the daemon's to fix, and the exposure tracks the
+  installed Docker Engine version rather than anything this library pins.
+  The `github.com/docker/docker` module carries both the daemon and the
+  client under one path, so an advisory against it may name daemon code
+  this provider never compiles — the client packages are all that reach a
+  consumer's binary.
 
 [`Shell`]: https://pkg.go.dev/github.com/ruffel/invoke#Shell


### PR DESCRIPTION
The docker submodule's dependencies raise security alerts that never become update PRs, because nothing watches the file they live in.

## Cause

`dependabot.yml` had one `gomod` entry, `directory: /`. That covers the **core** module's `go.mod` only. The submodule (`github.com/ruffel/invoke/docker`) is a separate Go module with its own `go.mod`, and it holds the docker SDK — the dependency behind all 10 of the current alerts. Dependabot alerts on it (via the dependency graph) but has never been configured to *update* it.

## Fix

A second `gomod` entry for `/docker`, with one dependency held out:

```yaml
    ignore:
      - dependency-name: "github.com/ruffel/invoke"
```

The submodule pins the core module to a released version **by hand**, repointed at release time (`RELEASING.md`). An automated bump would propose a version that doesn't exist yet — during development the pin points at the *last* release — and collide with the release process. Every third-party dependency in the submodule is still watched; only the intra-repo pin is left to the release workflow.

## Also: the security scope now states where Docker daemon risk sits

`SECURITY.md` gains a third scope boundary: the Docker daemon is trusted infrastructure the caller chose to talk to. `github.com/docker/docker` carries the daemon and the client under one module path, so an advisory against it may name daemon code this provider never compiles — the client packages are all that reach a consumer's binary, and daemon-side exposure tracks the installed Engine version, not anything this library pins. This is the reasoning behind dismissing the current alerts, recorded in the policy rather than only on the alerts.

## What this does and doesn't fix

- **Does:** the submodule's third-party dependencies now get update PRs, grouped like the root's; and the security policy explains the daemon/client distinction.
- **Doesn't:** the 10 current alerts — those are now **dismissed** (5 `not_used` for the daemon code we don't compile, 5 `inaccurate` for the misattribution to the root module). There was no update to apply: `v28.5.2+incompatible` is the newest Go module version that exists (the advisories' "fixed in 29.3.1" is a Docker *Engine* release, not a module tag). Verified:

  ```
  go get github.com/docker/docker@v29.3.1+incompatible → invalid version: unknown revision v29.3.1
  go list -m -versions github.com/docker/docker         → … v28.5.2+incompatible   (latest)
  ```

## Notes

- No behaviour change; a CI/dependency-config file and a docs file. `dependabot.yml` validated as YAML.
- The `ignore` name is checked against the current pin (`github.com/ruffel/invoke v0.4.0` in `docker/go.mod`).