### PR TITLE
docs: Unpin the install commands and link the published docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # invoke
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/ruffel/invoke.svg)](https://pkg.go.dev/github.com/ruffel/invoke)
+[![CI](https://github.com/ruffel/invoke/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ruffel/invoke/actions/workflows/ci.yml?query=branch%3Amain)
+
 Run commands and transfer files on the local machine, remote SSH hosts, and
 containers through one provider-agnostic Go interface.
 
 ```sh
-go get github.com/ruffel/invoke@v0.3.0
-go get github.com/ruffel/invoke/docker@v0.3.0   # only if you need containers
+go get github.com/ruffel/invoke
+go get github.com/ruffel/invoke/docker   # only if you need containers
 ```
+
+The API reference and runnable examples are on
+[pkg.go.dev](https://pkg.go.dev/github.com/ruffel/invoke); each release is
+documented on [GitHub Releases](https://github.com/ruffel/invoke/releases).
 
 ```go
 env, err := local.New()          // or ssh.New(ctx, host, ...), docker.New(ctx, container, ...)
@@ -15,7 +22,7 @@ if err != nil {
 }
 defer env.Close()
 
-res, stdout, _, err := invoke.NewExecutor(env).Output(ctx, invoke.New("uname", "-s"))
+_, stdout, _, err := invoke.NewExecutor(env).Output(ctx, invoke.New("uname", "-s"))
 ```
 
 Constructing the target is the only line that changes between them.

--- a/doc.go
+++ b/doc.go
@@ -19,7 +19,7 @@
 //	}
 //	defer env.Close()
 //
-//	res, stdout, _, err := invoke.NewExecutor(env).Output(ctx, invoke.New("uname", "-s"))
+//	_, stdout, _, err := invoke.NewExecutor(env).Output(ctx, invoke.New("uname", "-s"))
 //
 // [Command] is a plain value describing what to run. It carries no
 // streams and no state, so one can be run repeatedly, or against several


### PR DESCRIPTION
## What

- The `go get` lines no longer pin a version. The pinned `v0.3.0` was one release behind, and any manual pin re-stales on every release; unversioned `go get` resolves to the latest tag.
- The quickstart fragment binds `_` instead of `res`, which it never used, so it now pastes into a function body without a compile error and matches `ExampleNewExecutor`. Same one-line fix in the doc.go quickstart, which mirrors it.
- The README now links what was published but unreachable from it: the API reference and runnable examples on pkg.go.dev, release notes on GitHub Releases, and CI status (badges under the title).

## Why

The README is the front door: a reader lands there before pkg.go.dev, and until now it handed them an outdated version and no pointer to the examples or changelog that already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)