### PR TITLE
build: Retract the pre-rewrite versions, which no longer build

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,11 +58,6 @@ git tag docker/v0.2.0
 git push ruffel docker/v0.2.0
 ```
 
-After this, re-enable the submodule's arm of `just tidy` and
-`just tidy-check`, and add `cd docker && go mod tidy -diff` to the CI lint
-job: the reason they were skipped stops being true once a version exists
-to resolve.
-
 ## Verifying the release
 
 Tags are effectively permanent once the module proxy has seen them, so
@@ -92,12 +87,22 @@ The `release-verify` workflow does exactly this on every tag push, so it
 runs whether or not anyone remembers to.
 
 If it fails, the tag cannot be withdrawn — the proxy keeps serving it.
-Publish a corrected patch version instead.
+Publish a corrected patch version instead, and add the bad version to
+the `retract` block in go.mod so the go command steers consumers off it.
 
 ## History on the proxy
 
 Versions up to `v0.1.0` were published under an older layout, with
-providers in `providers/*` submodules that no longer exist. The proxy
-serves them permanently, so those module paths remain resolvable. Nothing
-needs to be done about them; `v0.2.0` supersedes `v0.1.0` for anyone
-asking for the latest, and the old paths simply stop receiving updates.
+providers in `providers/*` submodules. Those submodule tags were later
+deleted and the proxy never cached them, so the old versions resolve but
+do not build: `go get github.com/ruffel/invoke@v0.1.0` succeeds, and the
+consumer's next `go mod tidy` fails asking for `providers/*` revisions
+that no longer exist anywhere.
+
+`go.mod` therefore retracts `[v0.0.1, v0.1.0]`. The go command reads
+retractions from the latest release, then hides those versions from
+version lists and warns anyone already on them — so the directive takes
+effect with the first release that carries it. The `providers/*` paths
+themselves cannot be retracted: retraction is a statement a module makes
+about its own versions, and no new version of those paths will ever
+exist to make it.

--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// Pre-rewrite layout whose providers/* submodule tags were deleted;
+// these versions resolve but cannot build.
+retract [v0.0.1, v0.1.0]


### PR DESCRIPTION
## What

- `go.mod` retracts `[v0.0.1, v0.1.0]` with a rationale the go command will show. These are the pre-rewrite-layout releases; their `providers/*` submodule tags were deleted and the proxy never cached them.
- RELEASING.md's "History on the proxy" section now states what is actually true: those versions resolve but do not build — `go get github.com/ruffel/invoke@v0.1.0` succeeds, and the consumer's next `go mod tidy` fails asking for `providers/*` revisions that no longer exist anywhere. (The old claim was that the paths "remain resolvable" and nothing needs doing.)
- The bad-release remedy now mentions the retract block alongside "publish a corrected patch version".
- Dropped the one-time post-release step about re-enabling the submodule tidy arms — both halves (the Justfile arm and the CI `go mod tidy -diff` for docker) have been in place for a while, so the step only misleads the next releaser.

## Why

A consumer who lands on an old version should be told by their tooling, not by a failed build. Retraction is read from the latest release, so the directive starts protecting people with the next tag; the `providers/*` paths themselves cannot be retracted, since no new version of those module paths will ever exist to carry the statement — RELEASING.md now says that too.

## Verification

- `go mod edit -json` shows the retract range with its rationale.
- `just check` passes (`gomoddirectives` requires — and got — an explanation comment on the directive).