### PR TITLE
docs: Add a contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## Building and testing
+
+Go 1.25 or newer. The repository is two modules — the root and
+`docker/` — joined by a committed `go.work`, so a plain clone builds and
+tests with no setup.
+
+```sh
+just check              # format, lint, tidy, cross-build, race tests
+just test-integration   # everything needing a container runtime
+```
+
+Run `just check` before pushing. The integration lanes run the contract
+suite against a real OpenSSH server and a real container and compare
+the providers against each other; they need a container runtime, which
+is why they are not part of `just check`.
+
+## Commits and pull requests
+
+Commits and pull request titles are [Conventional
+Commits](https://www.conventionalcommits.org): `fix(ssh): ...`,
+`test(invoketest): ...`, one reviewable concern each.
+
+A change that breaks callers carries the `!` marker — `fix(fake)!: ...`.
+The marker is what tells the release draft to raise the minor rather
+than the patch; pre-1.0 a breaking change is a minor, and nothing here
+resolves to a major.
+
+Release notes are drafted automatically as pull requests merge, so a
+well-titled pull request is the changelog entry.
+
+## Behavior is specified by contracts
+
+Provider behavior is enforced by the executable suite in `invoketest`,
+not by prose. Two consequences for a change:
+
+- A fix to provider behavior lands with the contract that pins it, so
+  it cannot regress silently.
+- Every contract must be provably capable of failing: the suite's
+  self-test runs each contract against a defect-injected provider and
+  fails if any contract lacks a defect that makes it fail. A new
+  contract therefore registers one in the misbehave catalog
+  demonstrating it.
+
+An `Environment` implemented outside this repository can be verified
+against the same suite with `invoketest.Verify`.
+
+## Security
+
+Report vulnerabilities privately — see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -167,12 +167,8 @@ The integration lanes run the suite against a real OpenSSH server and a
 real container, and compare the providers against each other. They need a
 container runtime, so they are not part of `just check`.
 
-Commits and pull request titles are [Conventional
-Commits](https://www.conventionalcommits.org): `fix(ssh): ...`,
-`test(invoketest): ...`, one reviewable concern each. A change that breaks
-callers carries the `!` marker — `fix(fake)!: ...` — which is what tells
-the release draft to raise the minor rather than the patch. Pre-1.0 a
-breaking change is a minor; nothing here resolves to a major.
+Conventions for commits, pull requests, and behavioral changes are in
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## What

A root `CONTRIBUTING.md` covering: building and testing (`just check`, the integration lanes and why they need a container runtime, the two-module workspace), commit and PR conventions (Conventional Commits, the `!` breaking marker and what it does to the release draft, release notes drafted on merge), and the contract-first rule for behavioral changes — a fix lands with the contract that pins it, and every contract must be provably capable of failing via the misbehave catalog. Ends with a pointer to SECURITY.md for private reporting.

The README's Development section keeps the two commands and links here instead of carrying the conventions paragraph.

## Why

The conventions were real but scattered — a README paragraph, the self-test's enforcement, folklore. GitHub surfaces CONTRIBUTING.md in the pull-request banner, which is the moment a first-time contributor actually needs it.

## Verification

`just check` passes; all content was checked against what the repo actually does (Justfile recipes, release-drafter config, the invoketest self-test) rather than restating the old README text.