### PR TITLE
fix(fake)!: Treat quoted metacharacters as data, not syntax

### DIFF
--- a/fake/fake_test.go
+++ b/fake/fake_test.go
@@ -207,6 +207,88 @@ func TestUnsupportedShellSyntaxIsRefusedNotRun(t *testing.T) {
 	assert.Contains(t, err.Error(), "||", "the refusal must name what it could not run")
 }
 
+// TestQuotedMetacharactersAreDataAtRuntime pins what happens after
+// acceptance. The check at Start already lets a quoted metacharacter
+// through as data; the tokenizer must then keep treating it as data. A
+// quoted "2>&1" that rewires streams is the shell answering wrongly
+// without saying so — on every real target it is a plain argument.
+//
+// The same rule covers values that arrive by expansion: a variable or
+// substitution result is data wherever it lands, never syntax.
+func TestQuotedMetacharactersAreDataAtRuntime(t *testing.T) {
+	t.Parallel()
+
+	envCmd := invoke.Shell(`echo $REDIR`)
+	envCmd.Env = []string{"REDIR=2>&1"}
+
+	tests := []struct {
+		name       string
+		cmd        invoke.Command
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name:       "single-quoted duplication stays a word",
+			cmd:        invoke.Shell(`echo '2>&1'`),
+			wantStdout: "2>&1\n",
+		},
+		{
+			name:       "double-quoted duplication stays a word",
+			cmd:        invoke.Shell(`echo "2>&1"`),
+			wantStdout: "2>&1\n",
+		},
+		{
+			name:       "single-quoted null redirect stays a word",
+			cmd:        invoke.Shell(`echo '>/dev/null'`),
+			wantStdout: ">/dev/null\n",
+		},
+		{
+			name:       "an expanded value is data wherever it lands",
+			cmd:        envCmd,
+			wantStdout: "2>&1\n",
+		},
+		{
+			name:       "a substituted value is data wherever it lands",
+			cmd:        invoke.Shell(`echo $(printf '2>&1')`),
+			wantStdout: "2>&1\n",
+		},
+		{
+			name:       "a bare null redirect still rewires",
+			cmd:        invoke.Shell(`echo hi >/dev/null`),
+			wantStdout: "",
+		},
+		{
+			name:       "a bare duplication still rewires",
+			cmd:        invoke.Shell(`echo hi 1>&2`),
+			wantStderr: "hi\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := fake.New()
+
+			t.Cleanup(func() { _ = env.Close() })
+
+			var stdout, stderr bytes.Buffer
+
+			proc, err := env.Start(t.Context(), tt.cmd, invoke.IO{Stdout: &stdout, Stderr: &stderr})
+			require.NoError(t, err, "every script here is within the subset")
+
+			res, waitErr := proc.Wait()
+			require.NoError(t, waitErr, "want exit 0")
+			require.Equal(t, 0, res.ExitCode, "want exit 0")
+
+			assert.Equal(t, tt.wantStdout, stdout.String(),
+				"stdout must match what a real shell produces")
+			assert.Equal(t, tt.wantStderr, stderr.String(),
+				"stderr must match what a real shell produces")
+		})
+	}
+}
+
 // TestUnsupportedSyntaxNestedInQuotesIsRefusedLoudly covers the script
 // the check at Start cannot see: quoted, and so opaque until it runs.
 func TestUnsupportedSyntaxNestedInQuotesIsRefusedLoudly(t *testing.T) {

--- a/fake/shell.go
+++ b/fake/shell.go
@@ -427,24 +427,35 @@ func parseRedirect(word string) (redirect, bool) {
 	return redirect{}, false
 }
 
+// shellWord is one tokenized word together with how it was written.
+// Only a word written entirely bare can be a redirect: quoting makes a
+// metacharacter data, and an expansion's value is data wherever it
+// lands — which is how a real shell reads both.
+type shellWord struct {
+	text string
+	bare bool
+}
+
 // tokenize splits a simple command into argv words and redirects,
 // performing quote handling, $VAR expansion, and $() substitution. It
 // returns, in order: the argv words, the redirects, whether the command
 // parsed, and whether a substitution was interrupted by cancellation.
 func tokenize(ctx context.Context, s *session, text string) ([]string, []redirect, bool, bool) {
 	var (
-		words   []string
+		words   []shellWord
 		current strings.Builder
 	)
 
 	haveWord := false
+	bare := true
 
 	flush := func() {
 		if haveWord {
-			words = append(words, current.String())
+			words = append(words, shellWord{text: current.String(), bare: bare})
 			current.Reset()
 
 			haveWord = false
+			bare = true
 		}
 	}
 
@@ -457,19 +468,8 @@ func tokenize(ctx context.Context, s *session, text string) ([]string, []redirec
 
 			i++
 
-		case '\'':
-			end := indexRune(runes, i+1, '\'')
-			if end < 0 {
-				return nil, nil, false, false
-			}
-
-			current.WriteString(string(runes[i+1 : end]))
-
-			haveWord = true
-			i = end + 1
-
-		case '"':
-			segment, next, segOK, segInterrupted := expandDoubleQuoted(ctx, s, runes, i+1)
+		case '\'', '"', '$':
+			segment, next, segOK, segInterrupted := expandSegment(ctx, s, runes, i)
 			if segInterrupted {
 				return nil, nil, false, true
 			}
@@ -481,21 +481,7 @@ func tokenize(ctx context.Context, s *session, text string) ([]string, []redirec
 			current.WriteString(segment)
 
 			haveWord = true
-			i = next
-
-		case '$':
-			segment, next, segOK, segInterrupted := expandDollar(ctx, s, runes, i)
-			if segInterrupted {
-				return nil, nil, false, true
-			}
-
-			if !segOK {
-				return nil, nil, false, false
-			}
-
-			current.WriteString(segment)
-
-			haveWord = true
+			bare = false
 			i = next
 
 		default:
@@ -513,21 +499,47 @@ func tokenize(ctx context.Context, s *session, text string) ([]string, []redirec
 	return argv, redirects, true, false
 }
 
-// classifyWords separates tokenized words into argv and redirects.
-func classifyWords(words []string) ([]string, []redirect) {
+// expandSegment consumes one quoted or expanded segment starting at a
+// quote or a $, yielding the data it contributes to the current word.
+// It returns, in order: the segment, the index after it, whether it
+// parsed, and whether a substitution was interrupted.
+func expandSegment(ctx context.Context, s *session, runes []rune, at int) (string, int, bool, bool) {
+	switch runes[at] {
+	case '\'':
+		end := indexRune(runes, at+1, '\'')
+		if end < 0 {
+			return "", 0, false, false
+		}
+
+		return string(runes[at+1 : end]), end + 1, true, false
+
+	case '"':
+		return expandDoubleQuoted(ctx, s, runes, at+1)
+
+	default: // '$'
+		return expandDollar(ctx, s, runes, at)
+	}
+}
+
+// classifyWords separates tokenized words into argv and redirects. A
+// word carrying quoted or expanded content is never a redirect, however
+// much it looks like one.
+func classifyWords(words []shellWord) ([]string, []redirect) {
 	var (
 		argv      []string
 		redirects []redirect
 	)
 
 	for _, word := range words {
-		if r, isRedirect := parseRedirect(word); isRedirect {
-			redirects = append(redirects, r)
+		if word.bare {
+			if r, isRedirect := parseRedirect(word.text); isRedirect {
+				redirects = append(redirects, r)
 
-			continue
+				continue
+			}
 		}
 
-		argv = append(argv, word)
+		argv = append(argv, word.text)
 	}
 
 	return argv, redirects


### PR DESCRIPTION
## What

The fake shell classified redirections after quote removal and expansion, so quoted or expanded text could silently become live syntax:

- `echo '2>&1'` printed an empty line with stderr rewired to stdout — a real target prints `2>&1`.
- `echo '>/dev/null'` discarded its own output.
- `echo $REDIR` with `REDIR=2>&1` in the command's environment applied a redirection that was never in the script; `echo $(printf '2>&1')` likewise.

Each was a silent exit-0 wrong answer from a script the start-time check had correctly accepted — the shell's own pinned promise is that a metacharacter inside quotes is data, not syntax.

Tokenized words now record whether they were written entirely bare, and only a bare word can classify as a redirect. That matches how a real shell reads both halves: operators are recognized only unquoted, and an expansion's value is data wherever it lands. Bare redirections (`>/dev/null`, `1>&2`, …) rewire exactly as before. The three segment cases in the tokenizer collapsed into one `expandSegment` helper in the process.

## Why breaking

A test that relied on quoted or expanded text acting as a redirection now sees it as an argument — the behavior it would have had on any real target all along. Same category as the refusal change shipped previously: code that passed was passing on something untrue.

## Verification

- `TestQuotedMetacharactersAreDataAtRuntime` was written first and run against the unfixed shell: the five data cases failed, the two bare-redirection controls passed. After the fix all seven pass.
- `just check` is green, including the fake re-passing the full `invoketest` contract suite under `-race`.