### PR TITLE
fix(fake)!: Give the builtins their real answers, or a loud refusal

### DIFF
--- a/fake/builtins.go
+++ b/fake/builtins.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"io/fs"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -235,7 +236,17 @@ func runTest(s *session, args []string) int {
 		args = args[1:]
 	}
 
-	ok := evalTest(s, args)
+	ok, known := evalTest(s, args)
+	if !known {
+		// A form outside the simulated set is refused, never guessed
+		// at: a silent false reads as a verdict, and it would be a
+		// made-up one.
+		_, _ = io.WriteString(s.stderr,
+			"test: only the one-argument form and unary -e, -d, -f, -L, -n, -z, -t are simulated\n")
+
+		return 2
+	}
+
 	if negate {
 		ok = !ok
 	}
@@ -247,33 +258,51 @@ func runTest(s *session, args []string) int {
 	return 1
 }
 
-func evalTest(s *session, args []string) bool {
-	if len(args) != 2 {
-		return false
+// evalTest answers the simulated test forms. The second result reports
+// whether the form is one the fake can answer at all.
+func evalTest(s *session, args []string) (bool, bool) {
+	switch len(args) {
+	case 0:
+		// An empty expression is false, as POSIX has it.
+		return false, true
+	case 1:
+		// The one-argument form: true when the string is non-empty.
+		return args[0] != "", true
+	case 2:
+		return evalTestUnary(s, args[0], args[1])
+	default:
+		return false, false
+	}
+}
+
+func evalTestUnary(s *session, op, operand string) (bool, bool) {
+	switch op {
+	case "-n":
+		return operand != "", true
+	case "-z":
+		return operand == "", true
+	case "-t":
+		return false, true // The fake never allocates a terminal.
 	}
 
-	path := vfsClean(s.dir, args[1])
+	target := vfsClean(s.dir, operand)
 
-	node, exists := s.fs.snapshot(path)
+	node, exists := s.fs.snapshot(target)
 
-	switch args[0] {
+	switch op {
 	case "-e":
-		return exists
+		return exists, true
 	case "-d":
-		return exists && node.dir
+		return exists && node.dir, true
 	case "-f":
 		// A regular file: present, and neither a directory nor a link.
 		// The fake does not follow links here, which suffices for the
 		// contracts that probe already-materialized regular files.
-		return exists && !node.dir && node.link == ""
+		return exists && !node.dir && node.link == "", true
 	case "-L":
-		return exists && node.link != ""
-	case "-n":
-		return args[1] != ""
-	case "-t":
-		return false // The fake never allocates a terminal.
+		return exists && node.link != "", true
 	default:
-		return false
+		return false, false
 	}
 }
 
@@ -309,13 +338,45 @@ func runFind(s *session, args []string) int {
 }
 
 func runMkdir(s *session, args []string) int {
+	parents := false
 	if len(args) > 0 && args[0] == "-p" {
+		parents = true
 		args = args[1:]
 	}
 
 	for _, arg := range args {
-		if err := s.fs.mkdirAll(vfsClean(s.dir, arg)); err != nil {
+		target := vfsClean(s.dir, arg)
+
+		if !parents {
+			if code := checkMkdirPlain(s, arg, target); code != 0 {
+				return code
+			}
+		}
+
+		if err := s.fs.mkdirAll(target); err != nil {
 			_, _ = io.WriteString(s.stderr, "mkdir: "+err.Error()+"\n")
+
+			return 1
+		}
+	}
+
+	return 0
+}
+
+// checkMkdirPlain enforces what mkdir without -p cannot tolerate: an
+// existing target, or a missing parent. Tolerating either is -p's job,
+// and agreeing about a directory it did not create would be a verdict
+// the caller never earned.
+func checkMkdirPlain(s *session, arg, target string) int {
+	if _, exists := s.fs.snapshot(target); exists {
+		_, _ = io.WriteString(s.stderr, "mkdir: "+arg+": file exists\n")
+
+		return 1
+	}
+
+	if parent := path.Dir(target); parent != "/" {
+		if node, ok := s.fs.snapshot(parent); !ok || !node.dir {
+			_, _ = io.WriteString(s.stderr, "mkdir: "+arg+": no such file or directory\n")
 
 			return 1
 		}
@@ -337,15 +398,44 @@ func runTouch(s *session, args []string) int {
 }
 
 func runRm(s *session, args []string) int {
+	force := false
+
 	if len(args) > 0 && (args[0] == "-rf" || args[0] == "-fr" || args[0] == "-r" || args[0] == "-f") {
+		force = args[0] != "-r"
 		args = args[1:]
 	}
 
-	for _, arg := range args {
-		s.fs.removeAll(vfsClean(s.dir, arg))
+	if len(args) == 0 {
+		// Without -f, nothing to remove is an error, not a success.
+		if force {
+			return 0
+		}
+
+		_, _ = io.WriteString(s.stderr, "rm: missing operand\n")
+
+		return 1
 	}
 
-	return 0
+	status := 0
+
+	for _, arg := range args {
+		target := vfsClean(s.dir, arg)
+
+		if _, exists := s.fs.snapshot(target); !exists {
+			if force {
+				continue
+			}
+
+			_, _ = io.WriteString(s.stderr, "rm: "+arg+": no such file or directory\n")
+			status = 1
+
+			continue
+		}
+
+		s.fs.removeAll(target)
+	}
+
+	return status
 }
 
 func runDD(ctx context.Context, s *session, args []string) (int, bool) {

--- a/fake/fake.go
+++ b/fake/fake.go
@@ -36,9 +36,11 @@
 // The builtins are likewise a vocabulary rather than an implementation:
 // they cover the options the contract suite and ordinary shell-outs use.
 // Notably cat reads standard input and ignores file arguments, echo takes
-// no flags, and test and cd do not follow symbolic links. A script
-// needing more than the subset belongs in a handler registered with
-// [Environment.Handle], or on a real target.
+// no flags, and test and cd do not follow symbolic links. A form a
+// builtin does not simulate — a test operator outside its unary set,
+// most utility flags — fails loudly on standard error rather than being
+// answered falsely. A script needing more than the subset belongs in a
+// handler registered with [Environment.Handle], or on a real target.
 package fake
 
 import (

--- a/fake/fake_test.go
+++ b/fake/fake_test.go
@@ -207,6 +207,88 @@ func TestUnsupportedShellSyntaxIsRefusedNotRun(t *testing.T) {
 	assert.Contains(t, err.Error(), "||", "the refusal must name what it could not run")
 }
 
+// TestBuiltinsAnswerTruthfullyOrRefuse pins the builtins' failure modes
+// against what a real shell's utilities do. A silent wrong answer —
+// test reporting false for a form it never evaluated, mkdir agreeing
+// about a directory it did not create, rm agreeing about a path that
+// was never there — reads as a verdict, and it would be a made-up one.
+func TestBuiltinsAnswerTruthfullyOrRefuse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		script     string
+		env        []string
+		wantExit   int
+		wantStdout string
+		inStderr   string
+	}{
+		{name: "test -z on empty is true", script: `test -z ""`, wantExit: 0},
+		{name: "test -z on text is false", script: `test -z x`, wantExit: 1},
+		{name: "test one argument is its non-emptiness", script: `test abc`, wantExit: 0},
+		{name: "test one empty argument is false", script: `test ""`, wantExit: 1},
+		{name: "test refuses a binary form", script: `test a = a`, wantExit: 2, inStderr: "simulated"},
+		{name: "test refuses a numeric form", script: `test 1 -eq 1`, wantExit: 2, inStderr: "simulated"},
+		{name: "test refuses an unknown operator", script: `test -x /tmp`, wantExit: 2, inStderr: "simulated"},
+		{name: "mkdir fails on an existing path", script: `mkdir /tmp`, wantExit: 1, inStderr: "file exists"},
+		{name: "mkdir fails on a missing parent", script: `mkdir /a/b`, wantExit: 1, inStderr: "no such file or directory"},
+		{name: "mkdir -p tolerates both", script: `mkdir -p /a/b && mkdir -p /a/b`, wantExit: 0},
+		{name: "mkdir still creates", script: `mkdir /fresh && test -d /fresh`, wantExit: 0},
+		{name: "rm without an operand fails", script: `rm`, wantExit: 1, inStderr: "missing operand"},
+		{name: "rm fails on a missing path", script: `rm /missing`, wantExit: 1, inStderr: "no such file or directory"},
+		{name: "rm -f tolerates a missing path", script: `rm -f /missing`, wantExit: 0},
+		{name: "rm still removes", script: `touch /f && rm /f && test -e /f`, wantExit: 1},
+		{name: "exit refuses a non-numeric status", script: `exit abc`, wantExit: 2, inStderr: "numeric argument required"},
+		{
+			name:       "cd alone goes home",
+			script:     `mkdir -p /home/dev && cd && pwd`,
+			env:        []string{"HOME=/home/dev"},
+			wantExit:   0,
+			wantStdout: "/home/dev\n",
+		},
+		{
+			name:     "cd alone without HOME fails",
+			script:   `cd`,
+			env:      []string{"HOME="},
+			wantExit: 1,
+			inStderr: "HOME not set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := fake.New(fake.WithEnv(tt.env...))
+
+			t.Cleanup(func() { _ = env.Close() })
+
+			var stdout, stderr bytes.Buffer
+
+			proc, err := env.Start(t.Context(), invoke.Shell(tt.script), invoke.IO{Stdout: &stdout, Stderr: &stderr})
+			require.NoError(t, err, "every script here is within the subset")
+
+			res, waitErr := proc.Wait()
+			assert.Equal(t, tt.wantExit, res.ExitCode, "exit code must match a real shell's")
+
+			if tt.wantExit == 0 {
+				assert.NoError(t, waitErr)
+			} else {
+				var exitErr *invoke.ExitError
+
+				assert.ErrorAs(t, waitErr, &exitErr, "a non-zero answer is an ExitError, not a refusal")
+			}
+
+			assert.Equal(t, tt.wantStdout, stdout.String(), "stdout")
+
+			if tt.inStderr != "" {
+				assert.Contains(t, stderr.String(), tt.inStderr,
+					"the failure must say what went wrong")
+			}
+		})
+	}
+}
+
 // TestBracedNamesAndSpacedRedirectsRun pins the two spellings the shell
 // accepts as part of its subset: ${NAME} is the same expansion as
 // $NAME, and a space before /dev/null is the same redirection as the

--- a/fake/shell.go
+++ b/fake/shell.go
@@ -451,23 +451,9 @@ func execSimple(ctx context.Context, s *session, text string) (int, bool, bool) 
 
 	switch argv[0] {
 	case "exit":
-		code := 0
-		if len(argv) > 1 {
-			code, _ = strconv.Atoi(argv[1])
-		}
-
-		return code, true, false
-
+		return runExit(s, argv)
 	case "cd":
-		if len(argv) != 2 || !s.fs.isDir(vfsClean(s.dir, argv[1])) {
-			_, _ = io.WriteString(s.stderr, "cd: no such directory\n")
-
-			return 1, false, false
-		}
-
-		s.dir = vfsClean(s.dir, argv[1])
-
-		return 0, false, false
+		return runCD(s, argv)
 	}
 
 	sub := s.clone()
@@ -480,6 +466,56 @@ func execSimple(ctx context.Context, s *session, text string) (int, bool, bool) 
 
 // devNull is the only redirect target the shell simulates.
 const devNull = "/dev/null"
+
+// runExit answers the exit builtin. A status that is not a number is
+// the error a real shell reports, never a quiet zero.
+func runExit(s *session, argv []string) (int, bool, bool) {
+	if len(argv) == 1 {
+		return 0, true, false
+	}
+
+	code, err := strconv.Atoi(argv[1])
+	if err != nil {
+		_, _ = io.WriteString(s.stderr, "sh: exit: "+argv[1]+": numeric argument required\n")
+
+		return 2, true, false
+	}
+
+	return code, true, false
+}
+
+// runCD answers the cd builtin. Without an argument it goes where a
+// real shell goes: $HOME.
+func runCD(s *session, argv []string) (int, bool, bool) {
+	var target string
+
+	switch len(argv) {
+	case 1:
+		target = s.lookupEnv("HOME")
+		if target == "" {
+			_, _ = io.WriteString(s.stderr, "cd: HOME not set\n")
+
+			return 1, false, false
+		}
+	case 2:
+		target = argv[1]
+	default:
+		_, _ = io.WriteString(s.stderr, "cd: too many arguments\n")
+
+		return 1, false, false
+	}
+
+	dest := vfsClean(s.dir, target)
+	if !s.fs.isDir(dest) {
+		_, _ = io.WriteString(s.stderr, "cd: no such directory\n")
+
+		return 1, false, false
+	}
+
+	s.dir = dest
+
+	return 0, false, false
+}
 
 // redirect is one parsed redirection word.
 type redirect struct {


### PR DESCRIPTION
## What

`test` silently answered false for every form outside its unary set — `test -z \"\"`, `test a = a`, `test 1 -eq 1` — where every real shell exits 0. That is a made-up verdict in the one place a test suite is asking for a real one. Now:

- The simulated `test` forms gain `-z` and the POSIX one-argument form, both trivially answerable; `test` with no expression stays false, as POSIX has it.
- Everything else — binary forms, numeric comparisons, unknown operators — is refused loudly on stderr at exit 2, naming the simulated boundary the way `find` and `dd` already do.

The other builtins acquire the failure modes a real target has:

- `mkdir` without `-p` fails on an existing path (`file exists`) or a missing parent (`no such file or directory`) instead of quietly acting as `-p`.
- `rm` without `-f` fails on a missing operand or a missing path instead of exiting 0 having removed nothing; `-f` keeps its tolerance.
- `exit abc` reports `numeric argument required` at exit 2 instead of a quiet exit 0.
- `cd` with no argument goes to `$HOME` (failing plainly when HOME is empty), and `cd a b` says `too many arguments`.

The package doc's builtin caveats now state the refusal rule.

## Why breaking

A script that leaned on the lenient answers — an idempotent bare `mkdir`, an `rm` asserted to succeed on a path that was never there, a `test` comparison that "failed" without being evaluated — now sees the status a real target would have given it all along.

## Verification

- The 18-case behavior table was written first and run against the unfixed builtins: the 12 cases requiring new behavior failed, the 6 already-correct ones passed; all 18 pass after.
- The contract suite's own scripts use only unchanged forms (`mkdir -p`, `cd <dir>`, numeric `exit`, `test -n`), verified by scanning every fake-backed script in the repo.
- `just check` green, including the fake re-passing the full contract suite under `-race`.