### PR TITLE
fix(fake): Resolve names the same way in Start, LookPath, and scripts

### DIFF
--- a/fake/builtins.go
+++ b/fake/builtins.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ruffel/invoke"
 )
 
 // The builtin vocabulary is deliberately minimal: exactly the POSIX
@@ -28,9 +30,19 @@ func builtinKnown(name string) bool {
 // dispatch runs one command (top-level argv or a shell word) and returns
 // its exit code plus whether it was interrupted by cancellation.
 //
+// Registered handlers come first, as they do at Start: a name the
+// consumer scripted is theirs everywhere it can be written, builtin or
+// not.
+//
 //nolint:cyclop // A flat dispatch table over the builtin vocabulary.
 func dispatch(ctx context.Context, s *session, name string, args []string) (int, bool) {
-	switch name {
+	if handler, _ := s.owner.resolveCommand(name); handler != nil {
+		cmd := invoke.Command{Path: name, Args: args, Dir: s.dir}
+
+		return s.owner.runHandler(ctx, handler, cmd, s)
+	}
+
+	switch commandName(name) {
 	case "sh":
 		return runShellArgv(ctx, s, args)
 	case "sleep":

--- a/fake/fake.go
+++ b/fake/fake.go
@@ -47,6 +47,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path"
 	"sync"
 
 	"github.com/ruffel/invoke"
@@ -126,7 +127,11 @@ func New(opts ...Option) *Environment {
 }
 
 // Handle registers a handler for commands whose Path equals name,
-// overriding any builtin of the same name.
+// overriding any builtin of the same name. A handler is reachable
+// everywhere the name can be written: started directly, invoked from a
+// [invoke.Shell] script or a $(...) substitution, and through the path
+// LookPath reports for it. Calls records commands given to Start; a
+// script's internal invocations belong to the script.
 func (e *Environment) Handle(name string, h Handler) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -165,7 +170,7 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 		return nil, fmt.Errorf("fake: start: workdir %q: %w", cmd.Dir, invoke.ErrInvalidWorkdir)
 	}
 
-	handler, builtin := e.resolve(cmd.Path)
+	handler, builtin := e.resolveCommand(cmd.Path)
 	if handler == nil && !builtin {
 		return nil, fmt.Errorf("fake: start %q: %w", cmd.Path, invoke.ErrNotFound)
 	}
@@ -192,7 +197,8 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 	}), nil
 }
 
-// LookPath resolves name against the fake's handlers and builtins.
+// LookPath resolves name against the fake's handlers and builtins. The
+// answer is itself resolvable: what LookPath reports, Start accepts.
 func (e *Environment) LookPath(ctx context.Context, name string) (string, error) {
 	if err := e.checkOpen("lookpath"); err != nil {
 		return "", err
@@ -202,7 +208,11 @@ func (e *Environment) LookPath(ctx context.Context, name string) (string, error)
 		return "", fmt.Errorf("fake: lookpath: %w", err)
 	}
 
-	if handler, builtin := e.resolve(name); handler != nil || builtin {
+	if handler, builtin := e.resolveCommand(name); handler != nil || builtin {
+		if path.IsAbs(name) {
+			return name, nil
+		}
+
 		return "/usr/bin/" + name, nil
 	}
 
@@ -277,6 +287,34 @@ func (e *Environment) resolve(name string) (Handler, bool) {
 	}
 
 	return nil, builtinKnown(name)
+}
+
+// resolveCommand resolves an invoked path the way the target's own
+// lookup would: the exact registered or builtin name, or the basename
+// of the conventional /usr/bin home LookPath reports for every known
+// name. One rule serves Start, LookPath and the shell, so the three
+// cannot disagree about what exists.
+func (e *Environment) resolveCommand(pathStr string) (Handler, bool) {
+	if h, b := e.resolve(pathStr); h != nil || b {
+		return h, b
+	}
+
+	if alias := commandName(pathStr); alias != pathStr {
+		return e.resolve(alias)
+	}
+
+	return nil, false
+}
+
+// commandName maps an invoked path to the name the fake knows it by:
+// bare names as written, and the basename of the conventional /usr/bin
+// home.
+func commandName(pathStr string) string {
+	if dir, base := path.Split(pathStr); dir == "/usr/bin/" {
+		return base
+	}
+
+	return pathStr
 }
 
 func (e *Environment) record(cmd invoke.Command) {

--- a/fake/fake_test.go
+++ b/fake/fake_test.go
@@ -67,6 +67,145 @@ func TestHandlersOverrideBuiltinsAndRecordCalls(t *testing.T) {
 	assert.Equal(t, "--fast", calls[0].Args[1], "want the deploy invocation recorded")
 }
 
+// TestNamesResolveConsistently pins one rule across Start, LookPath and
+// the shell: a name the fake answers for is answerable everywhere it
+// can be written. A handler callable by Start but unknown to a script,
+// or a LookPath answer Start then refuses, is the fake disagreeing with
+// itself — and both patterns work on every real target.
+func TestNamesResolveConsistently(t *testing.T) {
+	t.Parallel()
+
+	newEnv := func(t *testing.T) *fake.Environment {
+		t.Helper()
+
+		env := fake.New()
+
+		t.Cleanup(func() { _ = env.Close() })
+
+		env.Handle("deploy", func(_ context.Context, _ invoke.Command, s *fake.Session) int {
+			_, _ = io.WriteString(s.Stdout, "deployed\n")
+
+			return 0
+		})
+
+		return env
+	}
+
+	runScript := func(t *testing.T, env *fake.Environment, script string) (invoke.Result, string, error) {
+		t.Helper()
+
+		var stdout bytes.Buffer
+
+		proc, err := env.Start(t.Context(), invoke.Shell(script), invoke.IO{Stdout: &stdout})
+		require.NoError(t, err, "the script must start")
+
+		res, waitErr := proc.Wait()
+
+		return res, stdout.String(), waitErr
+	}
+
+	t.Run("scripts reach registered handlers", func(t *testing.T) {
+		t.Parallel()
+
+		env := newEnv(t)
+
+		_, stdout, err := runScript(t, env, "deploy && echo done")
+		require.NoError(t, err)
+
+		assert.Equal(t, "deployed\ndone\n", stdout)
+	})
+
+	t.Run("substitutions reach registered handlers", func(t *testing.T) {
+		t.Parallel()
+
+		env := newEnv(t)
+
+		_, stdout, err := runScript(t, env, `echo "$(deploy)"`)
+		require.NoError(t, err)
+
+		assert.Equal(t, "deployed\n", stdout)
+	})
+
+	t.Run("a failing handler fails the script", func(t *testing.T) {
+		t.Parallel()
+
+		env := newEnv(t)
+		env.Handle("deploy", func(_ context.Context, _ invoke.Command, _ *fake.Session) int {
+			return 3
+		})
+
+		res, stdout, err := runScript(t, env, "deploy && echo done")
+
+		var exitErr *invoke.ExitError
+
+		require.ErrorAs(t, err, &exitErr, "the handler's failure is the script's failure")
+		assert.Equal(t, 3, res.ExitCode)
+		assert.Empty(t, stdout, "&& must not run its right side")
+	})
+
+	t.Run("handlers override builtins in scripts", func(t *testing.T) {
+		t.Parallel()
+
+		env := newEnv(t)
+		env.Handle("echo", func(_ context.Context, _ invoke.Command, s *fake.Session) int {
+			_, _ = io.WriteString(s.Stdout, "handled\n")
+
+			return 0
+		})
+
+		_, stdout, err := runScript(t, env, "echo native")
+		require.NoError(t, err)
+
+		assert.Equal(t, "handled\n", stdout, "Handle overrides a builtin in scripts as it does at Start")
+	})
+
+	t.Run("LookPath answers are startable", func(t *testing.T) {
+		t.Parallel()
+
+		env := newEnv(t)
+
+		for _, name := range []string{"echo", "deploy"} {
+			resolved, err := env.LookPath(t.Context(), name)
+			require.NoError(t, err, "LookPath(%q)", name)
+
+			var stdout bytes.Buffer
+
+			proc, err := env.Start(t.Context(), invoke.New(resolved), invoke.IO{Stdout: &stdout})
+			require.NoErrorf(t, err, "Start must accept LookPath's own answer %q", resolved)
+
+			_, err = proc.Wait()
+			require.NoError(t, err)
+		}
+	})
+
+	t.Run("the conventional path runs in scripts", func(t *testing.T) {
+		t.Parallel()
+
+		env := newEnv(t)
+
+		_, stdout, err := runScript(t, env, "/usr/bin/echo hi")
+		require.NoError(t, err)
+
+		assert.Equal(t, "hi\n", stdout)
+	})
+
+	t.Run("unknown names still fail everywhere", func(t *testing.T) {
+		t.Parallel()
+
+		env := newEnv(t)
+
+		_, err := env.LookPath(t.Context(), "nope")
+		assert.ErrorIs(t, err, invoke.ErrNotFound)
+
+		_, err = env.Start(t.Context(), invoke.New("/usr/bin/nope"), invoke.IO{})
+		assert.ErrorIs(t, err, invoke.ErrNotFound)
+
+		res, _, waitErr := runScript(t, env, "nope")
+		require.Error(t, waitErr)
+		assert.Equal(t, 127, res.ExitCode, "a script's unknown command stays the shell's 127")
+	})
+}
+
 func TestHandlerNonZeroExitIsExitError(t *testing.T) {
 	t.Parallel()
 

--- a/fake/process.go
+++ b/fake/process.go
@@ -23,6 +23,7 @@ type session struct {
 	dir    string
 	env    map[string]string
 	fs     *vfs
+	owner  *Environment
 }
 
 func (s *session) clone() *session {
@@ -205,6 +206,7 @@ func (e *Environment) newSession(cmd invoke.Command, stdio invoke.IO) *session {
 		dir:    dir,
 		env:    env,
 		fs:     e.fs,
+		owner:  e,
 	}
 
 	if s.stdin == nil {


### PR DESCRIPTION
## What

Two ways the fake disagreed with itself about what exists:

- A handler registered with `Handle("deploy", ...)` ran when started directly, but `invoke.Shell("deploy && echo done")` exited 127 `command not found`, and `$(deploy)` substituted empty at exit 0 — the docs steer scripts toward handlers without saying scripts cannot reach them.
- `LookPath("echo")` answered `/usr/bin/echo`, and `Start` then refused that very answer with `ErrNotFound`, because it resolved by exact string match. The natural pattern — resolve a tool, start the resolved path — works on every real provider and failed on the fake.

Resolution is now one rule serving Start, LookPath, and the shell: the exact registered or builtin name, or the basename of the conventional `/usr/bin` home LookPath reports. The shell dispatches to handlers before builtins, as Start always has, so `Handle` overrides a builtin everywhere the name can be written; the shell session carries a reference to its environment to make that reachable. `Handle`'s doc now states the reach, and that `Calls` records Start-level commands only — a script's internal invocations belong to the script.

Unknown names keep their honest failures: `ErrNotFound` from Start and LookPath, the shell's 127 from a script.

## Verification

- Seven-case test written first against the unfixed code: six failed (scripts/substitutions reaching handlers, handler failure propagation, handler-over-builtin in scripts, LookPath round-trip, /usr/bin form in scripts), the negative control passed; all seven pass after.
- `just check` green, including the fake re-passing the full contract suite under `-race`.