### PR TITLE
fix(fake): Unblock Wait and Close when a caller's stdin read never returns

### DIFF
--- a/fake/fake.go
+++ b/fake/fake.go
@@ -186,9 +186,9 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 
 	e.record(cmd)
 
-	s := e.newSession(cmd, stdio)
+	s, guard := e.newSession(cmd, stdio)
 
-	return e.spawn(ctx, func(runCtx context.Context) (int, bool) {
+	return e.spawn(ctx, guard, func(runCtx context.Context) (int, bool) {
 		if handler != nil {
 			return e.runHandler(runCtx, handler, cmd, s)
 		}

--- a/fake/fake_test.go
+++ b/fake/fake_test.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/ruffel/invoke"
 	"github.com/ruffel/invoke/fake"
@@ -251,6 +253,203 @@ func TestHandlerHonoringCancellationClassifiesAsCancel(t *testing.T) {
 
 	_, waitErr := proc.Wait()
 	assert.ErrorIs(t, waitErr, context.Canceled)
+}
+
+// releasableReader blocks every Read until released, then serves its
+// payload once and EOF thereafter, closing drained. It stands in for
+// the caller-supplied Stdin the fake cannot interrupt: an io.Pipe
+// nobody writes to, a network stream gone quiet.
+type releasableReader struct {
+	started     chan struct{}
+	release     chan struct{}
+	drained     chan struct{}
+	payload     []byte
+	startOnce   sync.Once
+	releaseOnce sync.Once
+	drainOnce   sync.Once
+	served      bool
+}
+
+func newReleasableReader(payload string) *releasableReader {
+	return &releasableReader{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		drained: make(chan struct{}),
+		payload: []byte(payload),
+	}
+}
+
+func (r *releasableReader) Read(p []byte) (int, error) {
+	r.startOnce.Do(func() { close(r.started) })
+
+	<-r.release
+
+	if r.served || len(r.payload) == 0 {
+		return 0, io.EOF
+	}
+
+	r.served = true
+	n := copy(p, r.payload)
+	r.drainOnce.Do(func() { close(r.drained) })
+
+	return n, nil
+}
+
+func (r *releasableReader) releaseNow() {
+	r.releaseOnce.Do(func() { close(r.release) })
+}
+
+// TestBlockedStdinCannotHangTheLifecycle pins the fake's version of a
+// guarantee the local provider engineered deliberately: a
+// caller-supplied Stdin whose Read never returns must not hang Wait,
+// Signal, or Close. Nothing in Go can interrupt such a read, so the
+// process is abandoned after a bounded grace — the caller released
+// with the right classification, and the wedged goroutine's writers
+// silenced so nothing lands in buffers whose owner has moved on.
+func TestBlockedStdinCannotHangTheLifecycle(t *testing.T) {
+	t.Parallel()
+
+	const bound = 8 * time.Second
+
+	start := func(t *testing.T, ctx context.Context) (*fake.Environment, invoke.Process, *releasableReader, *bytes.Buffer) {
+		t.Helper()
+
+		env := fake.New()
+
+		t.Cleanup(func() { _ = env.Close() })
+
+		reader := newReleasableReader("late\n")
+
+		t.Cleanup(reader.releaseNow)
+
+		var stdout bytes.Buffer
+
+		proc, err := env.Start(ctx, invoke.New("cat"), invoke.IO{Stdin: reader, Stdout: &stdout})
+		require.NoError(t, err)
+
+		<-reader.started // the body is now inside the caller's Read
+
+		return env, proc, reader, &stdout
+	}
+
+	awaitWait := func(t *testing.T, proc invoke.Process) error {
+		t.Helper()
+
+		results := make(chan error, 1)
+
+		go func() {
+			_, err := proc.Wait()
+			results <- err
+		}()
+
+		select {
+		case err := <-results:
+			return err
+		case <-time.After(bound):
+			t.Fatal("Wait did not return: a process wedged in a stdin read has hung the lifecycle")
+
+			return nil
+		}
+	}
+
+	t.Run("cancellation unblocks Wait", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		_, proc, _, _ := start(t, ctx)
+
+		cancel()
+
+		err := awaitWait(t, proc)
+		assert.ErrorIs(t, err, context.Canceled, "the interruption must be attributed to the caller's cancel")
+	})
+
+	t.Run("Close unblocks Wait", func(t *testing.T) {
+		t.Parallel()
+
+		_, proc, _, _ := start(t, t.Context())
+
+		closed := make(chan struct{})
+
+		go func() {
+			_ = proc.Close()
+
+			close(closed)
+		}()
+
+		select {
+		case <-closed:
+		case <-time.After(bound):
+			t.Fatal("Close did not return")
+		}
+
+		err := awaitWait(t, proc)
+		assert.ErrorIs(t, err, invoke.ErrClosed, "a process killed by Close reports ErrClosed")
+	})
+
+	t.Run("a signal unblocks Wait", func(t *testing.T) {
+		t.Parallel()
+
+		_, proc, _, _ := start(t, t.Context())
+
+		require.NoError(t, proc.Signal(invoke.SIGKILL), "the fake declares Signals")
+
+		err := awaitWait(t, proc)
+
+		var exitErr *invoke.ExitError
+
+		require.ErrorAs(t, err, &exitErr, "a delivered kill is a signal death")
+		assert.Equal(t, invoke.SIGKILL, exitErr.Signal)
+	})
+
+	t.Run("environment Close returns with a wedged process", func(t *testing.T) {
+		t.Parallel()
+
+		env, _, _, _ := start(t, t.Context())
+
+		closed := make(chan struct{})
+
+		go func() {
+			_ = env.Close()
+
+			close(closed)
+		}()
+
+		select {
+		case <-closed:
+		case <-time.After(bound):
+			t.Fatal("Environment.Close did not return while a process was wedged in a stdin read")
+		}
+	})
+
+	t.Run("an abandoned body cannot write into the caller's buffers", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		_, proc, reader, stdout := start(t, ctx)
+
+		cancel()
+
+		err := awaitWait(t, proc)
+		require.ErrorIs(t, err, context.Canceled)
+
+		// Wake the wedged goroutine after the fact: its Read now yields
+		// data, it will try to write, and the write must go nowhere.
+		// The guard was silenced before Wait returned, so even a write
+		// racing this assertion is a discarded one.
+		reader.releaseNow()
+
+		select {
+		case <-reader.drained:
+		case <-time.After(bound):
+			t.Fatal("the abandoned body never woke from its reader")
+		}
+
+		assert.Empty(t, stdout.String(),
+			"output delivered after Wait returned would race the caller's own reads")
+	})
 }
 
 func TestWithEnvSeedsBaseEnvironment(t *testing.T) {

--- a/fake/process.go
+++ b/fake/process.go
@@ -45,7 +45,8 @@ type process struct {
 	cancelRun context.CancelFunc
 	done      chan struct{}
 
-	// Set by the run goroutine before closing done.
+	// Set through finish or abandon before done is closed.
+	finishOnce  sync.Once
 	exitCode    int
 	interrupted bool
 
@@ -61,8 +62,20 @@ type process struct {
 	closeOnce sync.Once
 }
 
+// abandonGrace is how long a terminated body gets to finish before the
+// caller is released without it. It mirrors the local provider's
+// default termination grace: the same wedge — a read nothing can
+// interrupt — gets the same bounded patience.
+const abandonGrace = 2 * time.Second
+
 // spawn launches fn as the simulated process body.
-func (e *Environment) spawn(ctx context.Context, fn func(runCtx context.Context) (int, bool)) *process {
+//
+// The body owns the happy path: it publishes its outcome and releases
+// its context registration when it returns. A watcher covers the path
+// where the body cannot return — wedged in a caller-supplied Read that
+// nothing in Go can interrupt — by abandoning it a grace period after
+// its context is canceled, so Wait, Signal, and Close stay bounded.
+func (e *Environment) spawn(ctx context.Context, guard *outputGuard, fn func(runCtx context.Context) (int, bool)) *process {
 	runCtx, cancel := context.WithCancel(ctx)
 
 	p := &process{
@@ -76,9 +89,33 @@ func (e *Environment) spawn(ctx context.Context, fn func(runCtx context.Context)
 	e.track(p)
 
 	go func() {
-		defer close(p.done)
+		// Releasing the context registration on return keeps a
+		// long-lived parent context from accumulating one child per
+		// completed command.
+		defer cancel()
 
-		p.exitCode, p.interrupted = fn(runCtx)
+		// The deferred publish reports a panicking body as interrupted
+		// rather than leaving Wait blocked forever.
+		code, interrupted := -1, true
+
+		defer func() { p.finish(code, interrupted) }()
+
+		code, interrupted = fn(runCtx)
+	}()
+
+	go func() {
+		select {
+		case <-p.done:
+		case <-runCtx.Done():
+			timer := time.NewTimer(abandonGrace)
+			defer timer.Stop()
+
+			select {
+			case <-p.done:
+			case <-timer.C:
+				p.abandon(guard)
+			}
+		}
 	}()
 
 	return p
@@ -166,6 +203,32 @@ func (p *process) mapOutcome(duration time.Duration) (invoke.Result, error) {
 		errors.New("fake: wait: process interrupted for an unknown reason")
 }
 
+// finish publishes the body's own outcome, once.
+func (p *process) finish(code int, interrupted bool) {
+	p.finishOnce.Do(func() {
+		p.exitCode = code
+		p.interrupted = interrupted
+
+		close(p.done)
+	})
+}
+
+// abandon releases the caller from a body that did not stop when told
+// to. The writers are silenced first, so a goroutine that later comes
+// back to life cannot write into buffers whose owner was told the
+// process is over. Attribution is unaffected: whoever canceled the run
+// context recorded why before doing so.
+func (p *process) abandon(guard *outputGuard) {
+	p.finishOnce.Do(func() {
+		guard.silence()
+
+		p.exitCode = -1
+		p.interrupted = true
+
+		close(p.done)
+	})
+}
+
 // deliverableSignal reports whether the fake target delivers sig; the
 // whole supported set default-terminates a simulated process.
 func deliverableSignal(sig invoke.Signal) bool {
@@ -183,8 +246,51 @@ type emptyReader struct{}
 
 func (emptyReader) Read(_ []byte) (int, error) { return 0, io.EOF }
 
-// newSession materializes the execution state for one invocation.
-func (e *Environment) newSession(cmd invoke.Command, stdio invoke.IO) *session {
+// outputGuard stands between a process body and the caller's writers.
+// Silencing it discards all further writes, and blocks until any write
+// in flight has drained — after which nothing can land in the caller's
+// buffers, however late an abandoned goroutine wakes up.
+type outputGuard struct {
+	mu       sync.Mutex
+	silenced bool
+}
+
+// wrap guards w; a nil writer is the usual discard.
+func (g *outputGuard) wrap(w io.Writer) io.Writer {
+	if w == nil {
+		return io.Discard
+	}
+
+	return &guardedWriter{guard: g, w: w}
+}
+
+func (g *outputGuard) silence() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.silenced = true
+}
+
+type guardedWriter struct {
+	guard *outputGuard
+	w     io.Writer
+}
+
+func (w *guardedWriter) Write(b []byte) (int, error) {
+	w.guard.mu.Lock()
+	defer w.guard.mu.Unlock()
+
+	if w.guard.silenced {
+		return len(b), nil
+	}
+
+	return w.w.Write(b)
+}
+
+// newSession materializes the execution state for one invocation. The
+// returned guard silences the session's caller-facing writers if the
+// process is abandoned.
+func (e *Environment) newSession(cmd invoke.Command, stdio invoke.IO) (*session, *outputGuard) {
 	env := make(map[string]string, len(e.baseEnv)+len(cmd.Env))
 	maps.Copy(env, e.baseEnv)
 
@@ -199,10 +305,12 @@ func (e *Environment) newSession(cmd invoke.Command, stdio invoke.IO) *session {
 		dir = "/"
 	}
 
+	guard := &outputGuard{}
+
 	s := &session{
 		stdin:  stdio.Stdin,
-		stdout: stdio.Stdout,
-		stderr: stdio.Stderr,
+		stdout: guard.wrap(stdio.Stdout),
+		stderr: guard.wrap(stdio.Stderr),
 		dir:    dir,
 		env:    env,
 		fs:     e.fs,
@@ -213,13 +321,5 @@ func (e *Environment) newSession(cmd invoke.Command, stdio invoke.IO) *session {
 		s.stdin = emptyReader{}
 	}
 
-	if s.stdout == nil {
-		s.stdout = io.Discard
-	}
-
-	if s.stderr == nil {
-		s.stderr = io.Discard
-	}
-
-	return s
+	return s, guard
 }


### PR DESCRIPTION
## What

A fake process blocked in a caller-supplied `Stdin.Read` was immune to the entire lifecycle: cancel did nothing, `Signal(SIGKILL)` returned nil while `Wait` stayed blocked, `Close` hung on its internal Wait, and `Environment.Close` hung behind that. A test wiring an `io.Pipe` nobody writes to would wedge forever — where every real target dies promptly, and where the local provider built explicit machinery (`WaitDelay`, owned pipes) against this exact hazard.

Nothing in Go can interrupt a blocked `Read` on an arbitrary reader, so the fix is the one real targets use: **abandonment with a bounded grace**.

- A watcher gives a terminated body the same two seconds local's termination grace gives, then abandons it: `Wait`/`Close`/`Signal` observers are released with the correct classification (the canceler recorded its attribution before canceling — `context.Canceled`, `ErrClosed`, or the signal's `ExitError`).
- The abandoned goroutine is disowned with its caller-facing writers silenced first — silencing blocks until any in-flight write drains — so however late the goroutine wakes from its read, nothing lands in buffers whose owner has moved on.

Two smaller repairs ride the same machinery:

- A completed body now releases its context registration (`cancel` on return), so a long-lived cancellable parent no longer accumulates one child context per finished command.
- A panicking body publishes an interrupted outcome instead of the old silent exit 0.

## Verification

- Five-case test written first, each bounded so the hang fails fast instead of wedging the run: all five failed at the bound against the unfixed code (cancel, Close, signal, Environment.Close, silenced-writes), all five pass after — under `-race`, which also exercises the silence-before-release ordering.
- `just check` green, including the fake re-passing the full contract suite under `-race`.