### PR TITLE
test(invoketest): A wedged caller stdin must not hold Wait hostage

### DIFF
--- a/invoketest/contracts_lifecycle.go
+++ b/invoketest/contracts_lifecycle.go
@@ -19,6 +19,7 @@ func lifecycleContracts() []TestCase {
 		lifecycleWaitIsIdempotent(),
 		lifecycleConcurrentWaitIsSafe(),
 		lifecycleCancelUnblocksWait(),
+		lifecycleBlockedStdinCannotHangWait(),
 		lifecycleDeadlineUnblocksWait(),
 		lifecycleCancelTerminatesProcess(),
 		lifecycleCancelAfterExitKeepsOutcome(),
@@ -259,6 +260,56 @@ func lifecycleCancelUnblocksWait() TestCase {
 			assert.ErrorIs(t, outcome.err, context.Canceled)
 
 			requireNotExitError(t, outcome.err, "cancellation")
+		},
+	}
+}
+
+// lifecycleBlockedStdinCannotHangWait pins the wedge no provider can
+// interrupt: a caller-supplied Stdin whose Read never returns — an
+// io.Pipe nobody writes to, a network stream gone quiet.
+//
+// Nothing in Go can unblock that read, so the temptation is to wait for
+// it: a provider whose Wait joins the goroutine pumping the caller's
+// reader holds the caller hostage to a reader that owes it nothing,
+// long after the process is dead. The reader is the caller's property;
+// the process's end is the provider's. This contract keeps the two
+// apart.
+func lifecycleBlockedStdinCannotHangWait() TestCase {
+	return TestCase{
+		Category:    CategoryLifecycle,
+		Name:        "blocked-stdin-cannot-hang-wait",
+		Description: "A caller Stdin whose Read never returns cannot hold Wait or Close hostage once the process is told to stop",
+		Run: func(t T, env invoke.Environment) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			stdin := newBlockingReader()
+			defer stdin.release()
+
+			proc := startCommand(ctx, t, env, invoke.New("cat"), invoke.IO{Stdin: stdin})
+
+			defer func() { _ = proc.Close() }()
+
+			// The wedge must be real before it is tested: something —
+			// the provider's pump or the command itself — is now inside
+			// the caller's Read.
+			select {
+			case <-stdin.started:
+			case <-time.After(contractTimeout):
+				require.FailNow(t, "nothing read from the caller's stdin within the contract deadline")
+			}
+
+			cancel()
+
+			outcome := waitOrTimeout(t, proc)
+			require.Error(t, outcome.err, "Wait after cancel returned nil error")
+
+			assert.ErrorIs(t, outcome.err, context.Canceled,
+				"the interruption must be attributed to the caller's cancel, wedged stdin or not")
+
+			requireNotExitError(t, outcome.err, "cancellation with a wedged stdin")
+
+			assert.NoError(t, closeOrTimeout(t, proc), "Close after an abandoned stdin read")
 		},
 	}
 }

--- a/invoketest/helpers.go
+++ b/invoketest/helpers.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"io"
 	"sync"
 	"time"
 
@@ -36,6 +37,44 @@ func token(t T) string {
 // output says the command reached its final act, and this covers the
 // short walk from there to the process being gone.
 const exitSettle = 250 * time.Millisecond
+
+// blockingReader is a stdin whose first Read reports it began and then
+// holds — the caller-supplied reader no provider can interrupt: an
+// io.Pipe nobody writes to, a network stream gone quiet. Contracts
+// release it on the way out so a disowned pump goroutine can end.
+type blockingReader struct {
+	// started closes once something is inside Read, so a contract can
+	// wait for the wedge to be real rather than guess.
+	started chan struct{}
+
+	// held blocks the read until the contract releases it.
+	held chan struct{}
+
+	startOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingReader() *blockingReader {
+	return &blockingReader{
+		started: make(chan struct{}),
+		held:    make(chan struct{}),
+	}
+}
+
+// Read reports the first call, then blocks until released; a released
+// read reports end of input.
+func (r *blockingReader) Read(_ []byte) (int, error) {
+	r.startOnce.Do(func() { close(r.started) })
+
+	<-r.held
+
+	return 0, io.EOF
+}
+
+// release unblocks the read.
+func (r *blockingReader) release() {
+	r.releaseOnce.Do(func() { close(r.held) })
+}
 
 // blockingWriter is a destination for a process's output that reports the
 // first write and then holds it, so a contract can keep a provider inside

--- a/invoketest/misbehave_test.go
+++ b/invoketest/misbehave_test.go
@@ -59,6 +59,7 @@ type defects struct {
 	silentSignal         bool // Signal reports success and delivers nothing
 	plainSignalError     bool // unsupported signal errors without ErrNotSupported
 	waitFlipFlops        bool // a second Wait returns a different outcome
+	waitJoinsStdin       bool // hold Wait until the caller's stdin reader returns
 
 	// Classification defects.
 	plainMissingBinary bool // strip ErrNotFound from missing-binary failures
@@ -116,7 +117,20 @@ func (m *misbehaveEnv) Start(ctx context.Context, cmd invoke.Command, stdio invo
 		m.mu.Unlock()
 	}
 
-	proc, err := m.base.Start(startCtx, m.mutateCommand(cmd), m.mutateStdio(stdio))
+	stdio = m.mutateStdio(stdio)
+
+	// The waitJoinsStdin defect re-creates the tempting mistake: a Wait
+	// that joins the goroutine pumping the caller's reader, and so
+	// blocks until that reader deigns to return.
+	var stdinReturned chan struct{}
+
+	if m.d.waitJoinsStdin && stdio.Stdin != nil {
+		tracked := &returnTrackingReader{r: stdio.Stdin, returned: make(chan struct{})}
+		stdio.Stdin = tracked
+		stdinReturned = tracked.returned
+	}
+
+	proc, err := m.base.Start(startCtx, m.mutateCommand(cmd), stdio)
 	if err != nil {
 		m.release()
 
@@ -135,7 +149,21 @@ func (m *misbehaveEnv) Start(ctx context.Context, cmd invoke.Command, stdio invo
 		return nil, err
 	}
 
-	return &misbehaveProcess{base: proc, d: m.d, env: m, startCtx: ctx}, nil
+	return &misbehaveProcess{base: proc, d: m.d, env: m, startCtx: ctx, stdinReturned: stdinReturned}, nil
+}
+
+// returnTrackingReader reports, once, that a Read call has returned.
+type returnTrackingReader struct {
+	r        io.Reader
+	returned chan struct{}
+	once     sync.Once
+}
+
+func (r *returnTrackingReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	r.once.Do(func() { close(r.returned) })
+
+	return n, err
 }
 
 func (m *misbehaveEnv) LookPath(ctx context.Context, name string) (string, error) {
@@ -440,6 +468,10 @@ type misbehaveProcess struct {
 	startCtx context.Context //nolint:containedctx // Mirrors the real providers, which store the start context.
 	released sync.Once
 
+	// stdinReturned is non-nil under the waitJoinsStdin defect: Wait
+	// blocks on it, honoring a reader that owes it nothing.
+	stdinReturned chan struct{}
+
 	mu         sync.Mutex
 	waitCalls  int
 	closeCalls int
@@ -450,6 +482,11 @@ func (p *misbehaveProcess) Wait() (invoke.Result, error) {
 	// base.Wait is idempotent and concurrency-safe; call it without the
 	// lock so concurrent callers do not serialize on a blocking wait.
 	res, err := p.base.Wait()
+
+	if p.stdinReturned != nil {
+		<-p.stdinReturned
+	}
+
 	p.released.Do(p.env.release)
 
 	p.mu.Lock()
@@ -671,6 +708,7 @@ func defectCatalog() []defectCase {
 		{name: "flip-flopping concurrent wait", contract: "lifecycle/concurrent-wait-is-safe", defects: defects{waitFlipFlops: true}},
 		{name: "ignored cancel", contract: "lifecycle/cancel-unblocks-wait", defects: defects{ignoreCancel: true}},
 		{name: "cancel as exit error", contract: "lifecycle/cancel-unblocks-wait", defects: defects{exitErrorOnCancel: true}},
+		{name: "wait joins the caller's stdin", contract: "lifecycle/blocked-stdin-cannot-hang-wait", defects: defects{waitJoinsStdin: true}},
 		{name: "deadline as cancel", contract: "lifecycle/deadline-unblocks-wait", defects: defects{hardcodeCanceled: true}},
 		{name: "surviving process", contract: "lifecycle/cancel-terminates-process", defects: defects{ignoreCancel: true}},
 		{name: "late cancel overwrites exit", contract: "lifecycle/cancel-after-exit-keeps-outcome", defects: defects{cancelOverwritesExit: true}},


### PR DESCRIPTION
## What

A new lifecycle contract, `lifecycle/blocked-stdin-cannot-hang-wait`: start `cat` with a caller-supplied Stdin whose Read never returns, wait until something is demonstrably inside that Read, cancel — Wait must unblock within the contract deadline carrying the caller's own attribution (`context.Canceled`, never an `ExitError`), and Close must return. A `blockingReader` helper joins `blockingWriter` in the suite's vocabulary, released on the contract's way out so disowned pump goroutines can end.

The matching `waitJoinsStdin` misbehave defect re-creates the tempting mistake — a Wait that joins the goroutine pumping the caller's reader — so the self-test matrix proves the contract can fail.

## Why

Nothing in Go can interrupt a blocked Read on an arbitrary reader, so a provider that ties its Wait to the caller's reader holds the caller hostage to a reader that owes it nothing: an `io.Pipe` nobody writes to would hang Wait, Close, and Environment.Close forever, where every real target's process is long dead. The reader is the caller's property; the process's end is the provider's. Each provider satisfies this by deliberate engineering (local's owned stdin pipe, the fake's bounded abandonment, ssh and docker never joining their pumps) — deliberate engineering deserves a contract, or it regresses silently.

## Verification

- `just check` green: the contract passes against local, the fake, and the in-process SSH server, and the self-test matrix confirms it fails under its registered defect.
- Both integration lanes run and green: the real container (`-tags docker`) and a real OpenSSH server (`-tags openssh`).