### PR TITLE
fix(docker): Wait for an exec to stop before trusting its exit code

### DIFF
--- a/docker/process.go
+++ b/docker/process.go
@@ -461,10 +461,19 @@ func (p *process) inspect() (container.ExecInspect, error) {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), p.env.cfg.timeout())
 	defer cancel()
 
+	return p.env.settleInspect(ctx, p.execID)
+}
+
+// settleInspect reports an exec's status once the daemon agrees it has
+// stopped, allowing for the window where the stream has ended but the
+// daemon still calls the command running. An inspect answered inside
+// that window carries exit code zero, so trusting one mistakes an
+// unfinished command for a successful one.
+func (e *Environment) settleInspect(ctx context.Context, execID string) (container.ExecInspect, error) {
 	const settleInterval = 5 * time.Millisecond
 
 	for {
-		inspect, err := p.env.client.ContainerExecInspect(ctx, p.execID)
+		inspect, err := e.client.ContainerExecInspect(ctx, execID)
 		if err != nil {
 			return container.ExecInspect{}, &invoke.TransportError{Op: "inspect", Err: err}
 		}
@@ -545,9 +554,15 @@ func (e *Environment) runRaw(ctx context.Context, argv []string) (string, int, e
 		return "", -1, &invoke.TransportError{Op: "exec", Err: err}
 	}
 
-	inspect, err := e.client.ContainerExecInspect(ctx, resp.ID)
+	// Bounded independently of the caller's context, which may carry no
+	// deadline: a status that never settles must surface as an error
+	// rather than a spin.
+	settleCtx, cancel := context.WithTimeout(ctx, e.cfg.timeout())
+	defer cancel()
+
+	inspect, err := e.settleInspect(settleCtx, resp.ID)
 	if err != nil {
-		return stdout.String(), -1, &invoke.TransportError{Op: "inspect", Err: err}
+		return stdout.String(), -1, err
 	}
 
 	return stdout.String(), inspect.ExitCode, nil

--- a/docker/runraw_test.go
+++ b/docker/runraw_test.go
@@ -1,0 +1,96 @@
+package docker
+
+import (
+	"bufio"
+	"context"
+	"math"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/ruffel/invoke"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// settleStubClient serves a scripted exec whose inspect keeps calling
+// the command running for a few polls after its stream has ended — the
+// window a real daemon is entitled to. While an exec runs, its inspect
+// carries exit code zero.
+type settleStubClient struct {
+	client.APIClient
+
+	runningPolls int // inspects answered Running before settling
+	exitCode     int // the settled status
+
+	mu       sync.Mutex
+	inspects int
+}
+
+func (c *settleStubClient) ContainerExecCreate(_ context.Context, _ string, _ container.ExecOptions) (container.ExecCreateResponse, error) {
+	return container.ExecCreateResponse{ID: "exec-under-test"}, nil
+}
+
+func (c *settleStubClient) ContainerExecAttach(_ context.Context, _ string, _ container.ExecAttachOptions) (types.HijackedResponse, error) {
+	server, clientSide := net.Pipe()
+
+	// The command produces no output: its stream ends immediately,
+	// which is exactly when the daemon may still call it running.
+	_ = server.Close()
+
+	return types.HijackedResponse{Conn: clientSide, Reader: bufio.NewReader(clientSide)}, nil
+}
+
+func (c *settleStubClient) ContainerExecInspect(_ context.Context, _ string) (container.ExecInspect, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.inspects++
+	if c.inspects <= c.runningPolls {
+		return container.ExecInspect{Running: true}, nil
+	}
+
+	return container.ExecInspect{Running: false, ExitCode: c.exitCode}, nil
+}
+
+// TestRunRawWaitsForTheExecToStop pins runRaw to the same settling
+// discipline the main wait path uses: an inspect answered while the
+// exec still runs carries exit code zero, and trusting it mistakes an
+// unfinished command for a successful one — a racing LookPath returns
+// an empty path with a nil error, a pre-check passes a workdir it never
+// verified, a kill reports success for a kill that failed.
+func TestRunRawWaitsForTheExecToStop(t *testing.T) {
+	t.Parallel()
+
+	const settledExit = 7
+
+	stub := &settleStubClient{runningPolls: 3, exitCode: settledExit}
+	env := &Environment{client: stub, cfg: &Config{Timeout: 2 * time.Second}}
+
+	_, code, err := env.runRaw(t.Context(), []string{"probe"})
+	require.NoError(t, err)
+
+	assert.Equal(t, settledExit, code,
+		"runRaw must report the exec's settled status, not the zero an unfinished inspect carries")
+}
+
+// TestRunRawRefusesAnExecThatNeverStops pins the bounded half: a status
+// that never settles is reported as unresolved, never invented.
+func TestRunRawRefusesAnExecThatNeverStops(t *testing.T) {
+	t.Parallel()
+
+	stub := &settleStubClient{runningPolls: math.MaxInt}
+	env := &Environment{client: stub, cfg: &Config{Timeout: 500 * time.Millisecond}}
+
+	_, code, err := env.runRaw(t.Context(), []string{"probe"})
+
+	var transportErr *invoke.TransportError
+
+	require.ErrorAs(t, err, &transportErr,
+		"a status that never settles must be reported as unresolved, not invented as exit zero")
+	assert.Equal(t, -1, code)
+}


### PR DESCRIPTION
## What

`runRaw` — the helper behind `LookPath`, the workdir/executable pre-checks, shell detection, and `kill` — read `ContainerExecInspect` once after its stream ended and trusted the exit code. The daemon is entitled to a window where the stream has closed but the exec still reports `Running`, and an inspect answered inside it carries exit code zero. The main wait path already handles this with a settle loop and an honest unresolved error; `runRaw` did not, so a race could make `LookPath` return an empty path with a nil error, a pre-check pass a workdir it never verified, or `kill` report success for a failed kill.

Both paths now share one `settleInspect` loop. `runRaw` bounds it with the configured daemon timeout independently of the caller's context (which may carry no deadline), so a status that never settles is an unresolved `TransportError`, never an invented zero.

## Verification

- Two unit tests written first against a scripted client (the seam is the SDK interface, embedded and overridden): one whose inspect stays `Running` for three polls after the stream ends — `runRaw` returned 0 before, the settled status after — and one that never settles — nil error and 0 before, a bounded `TransportError` after. Both run daemon-free in the unit lane.
- `just check` green; the `-tags docker` integration lane against a real daemon green.