### PR TITLE
fix(docker): Keep WithMode off directories, as every other provider does

### DIFF
--- a/docker/tar.go
+++ b/docker/tar.go
@@ -33,7 +33,7 @@ func writeTree(ctx context.Context, tw *tar.Writer, src, base string, cfg invoke
 		return writeEntry(ctx, tw, src, base, base, info, cfg, src)
 	}
 
-	if err := writeDirHeader(tw, base, info, cfg); err != nil {
+	if err := writeDirHeader(tw, base, info); err != nil {
 		return err
 	}
 
@@ -65,7 +65,7 @@ func walkTree(ctx context.Context, tw *tar.Writer, dir, prefix, base, root strin
 		rel := strings.TrimPrefix(name, base+"/")
 
 		if info.IsDir() {
-			if err := writeDirHeader(tw, name, info, cfg); err != nil {
+			if err := writeDirHeader(tw, name, info); err != nil {
 				return err
 			}
 
@@ -117,13 +117,17 @@ func writeEntry(
 	}
 }
 
-// writeDirHeader records a directory and its mode, so the destination
-// does not inherit a default the source never had.
-func writeDirHeader(tw *tar.Writer, name string, info fs.FileInfo, cfg invoke.TransferConfig) error {
+// writeDirHeader records a directory and its own mode, so the
+// destination does not inherit a default the source never had. The
+// transfer's mode override is a statement about files and is not
+// consulted: forcing it onto directories produced a different tree
+// from the same call than every other provider — and 0600 on a
+// directory takes its execute bit, leaving it unusable.
+func writeDirHeader(tw *tar.Writer, name string, info fs.FileInfo) error {
 	return tw.WriteHeader(&tar.Header{
 		Typeflag: tar.TypeDir,
 		Name:     name + "/",
-		Mode:     int64(invoke.EffectiveMode(info.Mode(), cfg).Perm()),
+		Mode:     int64(info.Mode().Perm()),
 		ModTime:  info.ModTime(),
 	})
 }

--- a/docker/untar.go
+++ b/docker/untar.go
@@ -53,7 +53,9 @@ func extractTree(ctx context.Context, tr *tar.Reader, dst string, cfg invoke.Tra
 				return err
 			}
 
-			dirs = append(dirs, pendingDir{path: target, mode: headerMode(header, cfg)})
+			// A directory keeps the mode its header carries; the mode
+			// override is a statement about files.
+			dirs = append(dirs, pendingDir{path: target, mode: header.FileInfo().Mode().Perm()})
 
 			continue
 		}
@@ -216,7 +218,11 @@ func verifyContained(dst, p string) error {
 	return nil
 }
 
-// headerMode is the mode an extracted entry should carry.
+// headerMode is the mode an extracted file should carry: the
+// transfer's override when it set one, and otherwise the mode the
+// archive recorded. Directories do not pass through here — the
+// override is a statement about files, and a directory keeps the mode
+// its header carries.
 func headerMode(header *tar.Header, cfg invoke.TransferConfig) fs.FileMode {
 	if cfg.Mode != nil {
 		return *cfg.Mode

--- a/invoketest/contracts_transfer.go
+++ b/invoketest/contracts_transfer.go
@@ -34,6 +34,7 @@ func transferContracts() []TestCase {
 		transferRoundTrip(),
 		transferBinaryContentSurvives(),
 		transferModeOverride(),
+		transferModeOverrideIsFilesOnly(),
 		transferFailurePreservesDestination(),
 		transferCancelPreservesDestination(),
 		transferDownloadCancelPreservesDestination(),
@@ -359,6 +360,52 @@ func transferModeOverride() TestCase {
 
 			assert.Equal(t, "new content", readHostFile(t, downloadBack(t, env, remote)),
 				"the overwriting upload's content must win")
+		},
+	}
+}
+
+// transferModeOverrideIsFilesOnly pins which entries a mode override
+// touches. WithMode's contract is about files; a directory keeps its
+// own permissions. A provider that forces directories too produces a
+// different tree from the same call as every other provider — a
+// difference invisible until something permission-sensitive meets it.
+func transferModeOverrideIsFilesOnly() TestCase {
+	return TestCase{
+		Category:    CategoryTransfer,
+		Name:        "mode-override-is-files-only",
+		Description: "WithMode forces file modes and leaves directory modes alone, in both transfer directions",
+		Run: func(t T, env invoke.Environment) {
+			const dirMode = fs.FileMode(0o750)
+
+			src := t.TempDir()
+			sub := filepath.Join(src, "sub")
+			require.NoError(t, os.Mkdir(sub, dirMode), "fixture dir")
+			require.NoError(t, os.Chmod(sub, dirMode), "fixture dir mode, umask-proof")
+			writeHostFixture(t, sub, "leaf.txt", "content")
+
+			remote := "/tmp/invoke-xfer-" + token(t)
+
+			defer cleanupTargetPath(t, env, remote)
+
+			require.NoError(t, env.Upload(t.Context(), src, remote, invoke.WithMode(overrideMode)), "Upload")
+
+			assert.Truef(t, probeTargetMode(t, env, remote+"/sub/leaf.txt", overrideMode),
+				"uploaded file mode is not %v; WithMode must force file modes", overrideMode)
+			assert.Truef(t, probeTargetMode(t, env, remote+"/sub", dirMode),
+				"uploaded directory mode is not %v; WithMode must leave directory modes alone", dirMode)
+
+			back := filepath.Join(t.TempDir(), "back")
+			require.NoError(t, env.Download(t.Context(), remote, back, invoke.WithMode(overrideMode)), "Download")
+
+			leaf, err := os.Stat(filepath.Join(back, "sub", "leaf.txt"))
+			require.NoError(t, err, "downloaded file")
+			assert.Equal(t, overrideMode, leaf.Mode().Perm(),
+				"downloaded file mode; WithMode must force file modes")
+
+			subInfo, err := os.Stat(filepath.Join(back, "sub"))
+			require.NoError(t, err, "downloaded directory")
+			assert.Equal(t, dirMode, subInfo.Mode().Perm(),
+				"downloaded directory mode; WithMode must leave directory modes alone")
 		},
 	}
 }

--- a/invoketest/misbehave_test.go
+++ b/invoketest/misbehave_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,6 +72,7 @@ type defects struct {
 	corruptUploads           bool // upload garbage in place of the source
 	flattenModes             bool // force a fixed mode, ignoring source and option
 	dropModeOption           bool // strip WithMode from the options
+	modeOverrideOnDirs       bool // apply a WithMode override to directories too
 	destroyOnFailure         bool // clobber the upload destination when a transfer fails
 	destroyDownloadOnFailure bool // clobber the local destination when a download fails
 	shallowTrees             bool // upload only a tree's top-level files
@@ -222,6 +224,11 @@ func (m *misbehaveEnv) Upload(ctx context.Context, localPath, remotePath string,
 	}
 
 	err := m.base.Upload(ctx, src, remotePath, rebuilt...)
+
+	if err == nil && m.d.modeOverrideOnDirs && cfg.Mode != nil {
+		forceDirModes(remotePath, *cfg.Mode)
+	}
+
 	if err != nil && m.d.destroyOnFailure {
 		junk, junkErr := corruptCopyOf(localPath)
 		if junkErr == nil {
@@ -232,6 +239,19 @@ func (m *misbehaveEnv) Upload(ctx context.Context, localPath, remotePath string,
 	}
 
 	return err
+}
+
+// forceDirModes applies mode to every directory under root — the
+// modeOverrideOnDirs defect: a WithMode override leaking onto entries
+// it was never about.
+func forceDirModes(root string, mode fs.FileMode) {
+	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err == nil && d.IsDir() {
+			_ = os.Chmod(p, mode)
+		}
+
+		return nil
+	})
 }
 
 func (m *misbehaveEnv) Download(ctx context.Context, remotePath, localPath string, opts ...invoke.TransferOption) error {
@@ -736,6 +756,7 @@ func defectCatalog() []defectCase {
 		{name: "corrupted uploads", contract: "transfer/roundtrip-preserves-content-and-mode", defects: defects{corruptUploads: true}},
 		{name: "corrupted binary", contract: "transfer/binary-content-survives", defects: defects{corruptUploads: true}},
 		{name: "flattened modes", contract: "transfer/roundtrip-preserves-content-and-mode", defects: defects{flattenModes: true}},
+		{name: "mode override leaks onto directories", contract: "transfer/mode-override-is-files-only", defects: defects{modeOverrideOnDirs: true}},
 		{name: "dropped mode option", contract: "transfer/mode-override-applies-on-overwrite", defects: defects{dropModeOption: true}},
 		{name: "destroy on failure", contract: "transfer/failure-preserves-destination", defects: defects{destroyOnFailure: true}},
 		{name: "destroy on cancel", contract: "transfer/cancel-preserves-destination", defects: defects{destroyOnFailure: true}},


### PR DESCRIPTION
## What

`WithMode` forces file modes; a directory keeps its own. That is what the shared copy engine behind local and ssh does, what the fake does, and what the option's doc says ("forces mode on transferred files"). Docker was the outlier in both directions: `writeDirHeader` stamped the override into directory headers on upload, and extraction applied it to directories arriving from the container on download. The same `Upload(..., WithMode(0700))` produced `sub` at 700 via docker and 755 via local.

The difference is not cosmetic. `WithMode(0600)` took the execute bit off every directory — the new contract's download half failed on a bare `stat` inside the downloaded tree, which is exactly what a consumer's next step would have hit.

Directories now keep the mode their header carries, packing and extracting; files keep the override exactly as before.

## Contract

`transfer/mode-override-is-files-only` uploads a tree containing a 0750 directory under `WithMode(0600)` and expects the file forced and the directory untouched, then downloads it back under the same override and expects the same on the host — both directions, every provider. The `modeOverrideOnDirs` misbehave defect leaks the override onto directories, proving the contract can fail.

## Verification

- Contract written first: local, fake, and ssh passed it immediately (they conform); the docker integration lane failed it with the permission-denied symptom above — then passed after the fix.
- Self-test matrix green (contract fails under its defect, passes the reference); `just check` green; both integration lanes (real daemon, real OpenSSH) green under `-race`.