### PR TITLE
fix(docker): Replace a download destination atomically

### DIFF
--- a/docker/files.go
+++ b/docker/files.go
@@ -287,15 +287,42 @@ func (e *Environment) removeRemote(dir string) {
 	}
 }
 
-// replacePath moves src onto dst, replacing whatever is there.
+// replacePath moves src onto dst, replacing whatever kind of entry is
+// there — the host-side half of the promise moveRemote keeps inside the
+// container.
+//
+// Staging shares the destination's directory, so each rename here stays
+// on one filesystem. An existing destination is set aside rather than
+// removed, and only cleared once the new one is in its place, so a move
+// that fails leaves the original restored — never a destination deleted
+// ahead of a replacement that did not arrive.
 func replacePath(src, dst string) error {
-	if info, err := os.Lstat(dst); err == nil && info.IsDir() {
-		if err := os.RemoveAll(dst); err != nil {
-			return err
-		}
+	if _, err := os.Lstat(dst); err != nil {
+		// Nothing occupies the destination.
+		return os.Rename(src, dst)
 	}
 
-	return os.Rename(src, dst)
+	asideDir, err := os.MkdirTemp(filepath.Dir(dst), ".invoke-aside-")
+	if err != nil {
+		return err
+	}
+
+	aside := filepath.Join(asideDir, "previous")
+
+	if err := os.Rename(dst, aside); err != nil {
+		_ = os.Remove(asideDir)
+
+		return err
+	}
+
+	if err := os.Rename(src, dst); err != nil {
+		_ = os.Rename(aside, dst)
+		_ = os.RemoveAll(asideDir)
+
+		return err
+	}
+
+	return os.RemoveAll(asideDir)
 }
 
 // classifyTransfer folds a daemon failure into the package taxonomy.

--- a/docker/replace_test.go
+++ b/docker/replace_test.go
@@ -1,0 +1,180 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeReplaceFixture creates path's parents and writes content there.
+func writeReplaceFixture(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+// TestReplacePathReplacesAnyExistingEntry pins the host-side half of the
+// replace step to the same promise the container-side script keeps: a
+// download replaces whatever occupies its destination, whatever kind of
+// entry that is.
+func TestReplacePathReplacesAnyExistingEntry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		src     func(t *testing.T, dir string) string
+		dst     func(t *testing.T, dir string) string
+		probe   string // path under dst whose content proves the arrival won
+		content string
+	}{
+		{
+			name: "file over file",
+			src: func(t *testing.T, dir string) string {
+				t.Helper()
+
+				p := filepath.Join(dir, "staging", "arrived")
+				writeReplaceFixture(t, p, "new")
+
+				return p
+			},
+			dst: func(t *testing.T, dir string) string {
+				t.Helper()
+
+				p := filepath.Join(dir, "dest")
+				writeReplaceFixture(t, p, "old")
+
+				return p
+			},
+			probe:   "",
+			content: "new",
+		},
+		{
+			name: "directory over file",
+			src: func(t *testing.T, dir string) string {
+				t.Helper()
+
+				p := filepath.Join(dir, "staging", "arrived")
+				writeReplaceFixture(t, filepath.Join(p, "inner.txt"), "new tree")
+
+				return p
+			},
+			dst: func(t *testing.T, dir string) string {
+				t.Helper()
+
+				p := filepath.Join(dir, "dest")
+				writeReplaceFixture(t, p, "old file")
+
+				return p
+			},
+			probe:   "inner.txt",
+			content: "new tree",
+		},
+		{
+			name: "directory over symlink",
+			src: func(t *testing.T, dir string) string {
+				t.Helper()
+
+				p := filepath.Join(dir, "staging", "arrived")
+				writeReplaceFixture(t, filepath.Join(p, "inner.txt"), "new tree")
+
+				return p
+			},
+			dst: func(t *testing.T, dir string) string {
+				t.Helper()
+
+				target := filepath.Join(dir, "elsewhere")
+				writeReplaceFixture(t, target, "link target")
+
+				p := filepath.Join(dir, "dest")
+				require.NoError(t, os.Symlink(target, p))
+
+				return p
+			},
+			probe:   "inner.txt",
+			content: "new tree",
+		},
+		{
+			name: "file over directory",
+			src: func(t *testing.T, dir string) string {
+				t.Helper()
+
+				p := filepath.Join(dir, "staging", "arrived")
+				writeReplaceFixture(t, p, "new")
+
+				return p
+			},
+			dst: func(t *testing.T, dir string) string {
+				t.Helper()
+
+				p := filepath.Join(dir, "dest")
+				writeReplaceFixture(t, filepath.Join(p, "stale.txt"), "old tree")
+
+				return p
+			},
+			probe:   "",
+			content: "new",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			src := tt.src(t, dir)
+			dst := tt.dst(t, dir)
+
+			require.NoError(t, replacePath(src, dst),
+				"a download replaces whatever occupies its destination")
+
+			read := dst
+			if tt.probe != "" {
+				read = filepath.Join(dst, tt.probe)
+			}
+
+			got, err := os.ReadFile(read)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.content, string(got), "the arrival must win")
+		})
+	}
+}
+
+// TestReplacePathFailurePreservesTheDestination pins the aside-restore
+// promise: a replacement that cannot move into place leaves the
+// original destination exactly where it was — never deleted ahead of a
+// replacement that did not arrive.
+func TestReplacePathFailurePreservesTheDestination(t *testing.T) {
+	t.Parallel()
+
+	const readOnlyDir = os.FileMode(0o555)
+
+	dir := t.TempDir()
+
+	dst := filepath.Join(dir, "dest")
+	writeReplaceFixture(t, filepath.Join(dst, "keep.txt"), "precious destination")
+
+	stagingParent := filepath.Join(dir, "staging")
+	src := filepath.Join(stagingParent, "arrived")
+	writeReplaceFixture(t, filepath.Join(src, "new.txt"), "never lands")
+
+	// The final rename must remove src from its parent, which a
+	// read-only parent refuses — after the destination has already been
+	// set aside.
+	require.NoError(t, os.Chmod(stagingParent, readOnlyDir))
+
+	t.Cleanup(func() { _ = os.Chmod(stagingParent, 0o755) })
+
+	require.Error(t, replacePath(src, dst), "the move cannot succeed")
+
+	got, err := os.ReadFile(filepath.Join(dst, "keep.txt"))
+	require.NoError(t, err,
+		"the destination was deleted ahead of a replacement that did not arrive")
+
+	assert.Equal(t, "precious destination", string(got),
+		"a failed replacement must leave the original destination intact")
+}


### PR DESCRIPTION
## What

Download's host-side replace step (`replacePath`) was weaker than Upload's container-side one (`moveRemote`) in both ways that matter:

- A directory arriving over an existing **file or symlink** failed with `ENOTDIR` — only an existing directory was cleared before the rename.
- The clearing itself was the hazard: `RemoveAll` ran **before** the rename, so a rename that then failed (permissions, races) left no original to restore — the "destination deleted ahead of a replacement that did not arrive" that `moveRemote`'s script explicitly prevents inside the container.

`replacePath` now keeps the same promise: an existing destination of any kind is set aside via a same-filesystem rename (a fresh `MkdirTemp` sibling, so the name cannot collide), the arrival moves into place, and only then is the aside cleared. A failed move restores the original.

## Verification

- Tests written first, daemon-free: four replacement-kind cases (dir-over-file and dir-over-symlink failed before; file-over-file and file-over-dir already passed) and a failure-preservation case that makes the final rename fail after the destination is set aside — the original was deleted before, and survives intact after.
- `just check` green; the `-tags docker` integration lane (which exercises the download contracts end-to-end against a real daemon) green under `-race`.