### PR TITLE
fix(docker): Precedence and classification minors

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ staging transfers. Without one, both report `ErrNotSupported` rather than
 misbehaving.
 
 **Docker finds its daemon the way the `docker` command does**: an endpoint
-passed to `WithHost`, then `DOCKER_HOST`, then the current context. A
-context reached over TLS is reported as unsupported rather than connected
-to without its certificates.
+passed to `WithHost`, then a context named with `WithContext`, then
+`DOCKER_HOST`, then the current context. A context reached over TLS is
+reported as unsupported rather than connected to without its
+certificates.
 
 **A command can outlive its own exit.** Something it left running may still
 hold its output open, so `Wait` gives up after a grace period rather than

--- a/docker/classify_test.go
+++ b/docker/classify_test.go
@@ -1,0 +1,65 @@
+package docker
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ruffel/invoke"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClassifyStartReadsTheRightPattern pins classification against the
+// daemon's real message shapes. The hazard is order: runc's workdir
+// failure ends in "no such file or directory", so a classifier that
+// checks the missing-binary patterns first blames the executable for a
+// directory that does not exist.
+func TestClassifyStartReadsTheRightPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		message  string
+		sentinel error
+	}{
+		{
+			name: "a missing workdir is the workdir's fault",
+			message: `OCI runtime create failed: runc create failed: unable to start container process: ` +
+				`chdir to cwd ("/missing") set in config.json failed: no such file or directory: unknown`,
+			sentinel: invoke.ErrInvalidWorkdir,
+		},
+		{
+			name: "a workdir that is a file is the workdir's fault",
+			message: `OCI runtime create failed: runc create failed: unable to start container process: ` +
+				`chdir to cwd ("/etc/hosts") set in config.json failed: not a directory: unknown`,
+			sentinel: invoke.ErrInvalidWorkdir,
+		},
+		{
+			name: "a missing executable is the executable's fault",
+			message: `OCI runtime exec failed: exec failed: unable to start container process: ` +
+				`exec: "no-such-tool": executable file not found in $PATH: unknown`,
+			sentinel: invoke.ErrNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := classifyStart(errors.New(tt.message))
+
+			assert.ErrorIs(t, err, tt.sentinel, "daemon message: %s", tt.message)
+		})
+	}
+
+	t.Run("an unrecognized failure stays a transport error", func(t *testing.T) {
+		t.Parallel()
+
+		err := classifyStart(errors.New("the daemon fell over"))
+
+		var transportErr *invoke.TransportError
+
+		require.ErrorAs(t, err, &transportErr,
+			"an unclassified start failure is the transport's to explain")
+	})
+}

--- a/docker/context.go
+++ b/docker/context.go
@@ -29,7 +29,7 @@ const defaultContextName = "default"
 // An empty result means the client's own defaults apply.
 func resolveHost(cfg *Config) (string, error) {
 	// An explicit endpoint is the caller's decision and outranks
-	// everything, as does the environment the docker command reads first.
+	// everything.
 	if cfg.Host != "" {
 		if err := checkEndpoint(cfg.Host); err != nil {
 			return "", err
@@ -38,15 +38,23 @@ func resolveHost(cfg *Config) (string, error) {
 		return cfg.Host, nil
 	}
 
-	if host := os.Getenv("DOCKER_HOST"); host != "" {
-		if err := checkEndpoint(host); err != nil {
-			return "", err
-		}
+	name, explicit := contextName(cfg)
 
-		return "", nil
+	// The environment the docker command reads outranks the stored
+	// current context, but not a context somebody named: docker
+	// --context beats DOCKER_HOST, WithContext is that flag, and
+	// DOCKER_CONTEXT gets the same warning-and-preference from the
+	// docker command itself.
+	if !explicit {
+		if host := os.Getenv("DOCKER_HOST"); host != "" {
+			if err := checkEndpoint(host); err != nil {
+				return "", err
+			}
+
+			return "", nil
+		}
 	}
 
-	name, explicit := contextName(cfg)
 	if name == "" || name == defaultContextName {
 		return "", nil
 	}

--- a/docker/context_test.go
+++ b/docker/context_test.go
@@ -72,7 +72,7 @@ func TestResolveHostPrefersExplicitSettings(t *testing.T) {
 	})
 
 	//nolint:paralleltest // t.Setenv forbids t.Parallel.
-	t.Run("environment beats the context", func(t *testing.T) {
+	t.Run("environment beats the current context", func(t *testing.T) {
 		writeContext(t, "colima", "colima", "unix:///from/context.sock")
 		t.Setenv("DOCKER_HOST", "tcp://from-env:2375")
 
@@ -91,6 +91,31 @@ func TestResolveHostPrefersExplicitSettings(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "unix:///from/other.sock", host)
+	})
+
+	//nolint:paralleltest // t.Setenv forbids t.Parallel.
+	t.Run("a named context beats the environment", func(t *testing.T) {
+		writeContext(t, "colima", "colima", "unix:///from/context.sock")
+		t.Setenv("DOCKER_HOST", "tcp://from-env:2375")
+
+		host, err := resolveHost(&Config{Context: "colima"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "unix:///from/context.sock", host,
+			"docker --context beats DOCKER_HOST, and WithContext is that flag")
+	})
+
+	//nolint:paralleltest // t.Setenv forbids t.Parallel.
+	t.Run("DOCKER_CONTEXT beats DOCKER_HOST", func(t *testing.T) {
+		writeContext(t, "", "colima", "unix:///from/context.sock")
+		t.Setenv("DOCKER_CONTEXT", "colima")
+		t.Setenv("DOCKER_HOST", "tcp://from-env:2375")
+
+		host, err := resolveHost(&Config{})
+		require.NoError(t, err)
+
+		assert.Equal(t, "unix:///from/context.sock", host,
+			"the docker command warns and prefers DOCKER_CONTEXT; so does this")
 	})
 }
 

--- a/docker/environment.go
+++ b/docker/environment.go
@@ -3,8 +3,9 @@
 // invoketest contract suite.
 //
 // The daemon is found the way the docker command finds it: an endpoint
-// passed to [WithHost], then DOCKER_HOST, then the endpoint recorded by
-// the current context — which is where installations that do not use the
+// passed to [WithHost], then a context named by [WithContext] or
+// DOCKER_CONTEXT, then DOCKER_HOST, then the endpoint recorded by the
+// current context — which is where installations that do not use the
 // conventional socket, such as Colima and Rancher Desktop, put theirs.
 //
 // Commands are delivered to the daemon as a real argument vector, so

--- a/docker/options.go
+++ b/docker/options.go
@@ -29,7 +29,8 @@ type Config struct {
 	Host string
 
 	// Context names a docker context to take the endpoint from,
-	// overriding whichever one is current.
+	// overriding whichever one is current — and DOCKER_HOST, as the
+	// docker command's own --context flag does.
 	Context string
 
 	// Timeout bounds daemon calls that must not block indefinitely;
@@ -57,7 +58,9 @@ func WithHost(host string) Option {
 }
 
 // WithContext takes the daemon endpoint from the named docker context,
-// rather than from whichever one the installation currently selects.
+// rather than from whichever one the installation currently selects —
+// overriding an ambient DOCKER_HOST too, as the docker command's own
+// --context flag does.
 //
 // Naming a context that cannot be read fails, rather than falling back to
 // the default endpoint: the fallback is a different daemon, and commands

--- a/docker/process.go
+++ b/docker/process.go
@@ -576,15 +576,19 @@ func classifyStart(err error) error {
 	msg := err.Error()
 
 	switch {
-	case strings.Contains(msg, "executable file not found"),
-		strings.Contains(msg, "no such file or directory"),
-		strings.Contains(msg, "starting container process caused: exec"):
-		return fmt.Errorf("docker: start: %w", invoke.ErrNotFound)
-
+	// The workdir patterns are read first: runc's chdir failure ends in
+	// "no such file or directory", and reading the missing-binary
+	// patterns before it blamed the executable for a directory that
+	// does not exist.
 	case strings.Contains(msg, "no such directory"),
 		strings.Contains(msg, "not a directory"),
 		strings.Contains(msg, "chdir"):
 		return fmt.Errorf("docker: start: workdir: %w", invoke.ErrInvalidWorkdir)
+
+	case strings.Contains(msg, "executable file not found"),
+		strings.Contains(msg, "no such file or directory"),
+		strings.Contains(msg, "starting container process caused: exec"):
+		return fmt.Errorf("docker: start: %w", invoke.ErrNotFound)
 
 	default:
 		return &invoke.TransportError{Op: "start", Err: err}
@@ -643,13 +647,10 @@ func signalNumber(sig invoke.Signal) (int, bool) {
 }
 
 // supportedSignal reports whether sig is in the portable signal set the
-// provider delivers.
+// provider delivers: exactly the names it can number for kill, so the
+// two cannot drift apart.
 func supportedSignal(sig invoke.Signal) bool {
-	switch sig {
-	case invoke.SIGINT, invoke.SIGTERM, invoke.SIGKILL, invoke.SIGHUP,
-		invoke.SIGQUIT, invoke.SIGUSR1, invoke.SIGUSR2:
-		return true
-	default:
-		return false
-	}
+	_, ok := linuxSignalNumbers[sig]
+
+	return ok
 }

--- a/docker/tar.go
+++ b/docker/tar.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"archive/tar"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -275,10 +274,6 @@ func (r *progressReader) Read(p []byte) (int, error) {
 	if n > 0 {
 		r.current += int64(n)
 		r.fn(invoke.TransferProgress{Path: r.path, Current: r.current, Total: r.total})
-	}
-
-	if err != nil && !errors.Is(err, io.EOF) {
-		return n, err
 	}
 
 	return n, err

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -608,10 +607,6 @@ func (r *progressReader) Read(p []byte) (int, error) {
 	if n > 0 {
 		r.current += int64(n)
 		r.fn(invoke.TransferProgress{Path: r.path, Current: r.current, Total: r.total})
-	}
-
-	if err != nil && !errors.Is(err, io.EOF) {
-		return n, err
 	}
 
 	return n, err


### PR DESCRIPTION
## What

Four small repairs, each aligning behavior with something already promised:

- **`WithContext` beats `DOCKER_HOST`.** The option's doc says it "takes the daemon endpoint from the named docker context", but an ambient `DOCKER_HOST` silently won — commands ran on a daemon the caller did not choose. Now a context named via `WithContext` or `DOCKER_CONTEXT` outranks the environment, exactly as `docker --context` behaves (the CLI warns and prefers the named context when both are set). `DOCKER_HOST` still outranks the stored *current* context. The discovery docs (package doc, option docs, README) now state the full order: `WithHost` → named context → `DOCKER_HOST` → current context.
- **A missing workdir is the workdir's fault.** runc's chdir failure ends in "no such file or directory", and `classifyStart` checked the missing-binary patterns first, so a bad `Dir` classified as `ErrNotFound` — reachable in a shell-less container, where no pre-check runs ahead of the daemon. Workdir patterns are now read first.
- **One signal table.** `supportedSignal` re-listed the seven names `linuxSignalNumbers` maps; it is now a lookup in that map, so the deliverable set and the numberable set cannot drift.
- **Dead branch dropped** in `progressReader.Read`, in both its verbatim copies (docker's packer and the shared engine): the conditional's two paths returned the same pair.

## Verification

- Tests written first: two new precedence cases (named-context-beats-env, `DOCKER_CONTEXT`-beats-`DOCKER_HOST`) failed before and pass after, alongside the existing precedence cases which stay green; a new `classifyStart` table over real runc message shapes had the chdir case red before and green after.
- `just check` green in both modules; the `-tags docker` integration lane against a real daemon green under `-race`.