### PR TITLE
fix(ssh): Make env-file delivery failures fire, classify, and clean up

### DIFF
--- a/ssh/command.go
+++ b/ssh/command.go
@@ -73,10 +73,15 @@ func exportPrologue(pairs []string) string {
 //
 // Failing to read it exits rather than running the command without its
 // environment, which is the outcome this whole route exists to avoid.
+// The readability test stands on its own ahead of the source: dot is a
+// special built-in, and a POSIX shell aborts outright when one fails,
+// skipping any || that was waiting to catch it — the guard would never
+// fire from where it looks like it belongs.
 func sourcePrologue(path string) string {
 	quoted := quoteArg(path)
 
-	return ". " + quoted + " || exit " + strconv.Itoa(envDeliveryFailed) + "; rm -f " + quoted + "; "
+	return "[ -r " + quoted + " ] || exit " + strconv.Itoa(envDeliveryFailed) + "; " +
+		". " + quoted + "; rm -f " + quoted + "; "
 }
 
 // Exit codes used by the pre-flight check to distinguish a missing working
@@ -88,6 +93,12 @@ const (
 
 	// envDeliveryFailed reports that the environment file could not be
 	// read, so the command was not run.
+	//
+	// The status is reserved on the file-delivery route: unlike the
+	// pre-check statuses, which run in an exec of their own, this one
+	// shares the command's session, so a command of its own exiting 93
+	// under that route is read as a delivery failure. WithCommandLineEnv
+	// avoids the file and with it the reservation.
 	envDeliveryFailed = 93
 )
 

--- a/ssh/exec_test.go
+++ b/ssh/exec_test.go
@@ -250,3 +250,129 @@ func TestNonZeroExitSurvivesConcurrentCancel(t *testing.T) {
 type writerFunc func([]byte) (int, error)
 
 func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
+// deliveredEnvFile digs the delivery file's path out of the recorded
+// execs, so a test can check what became of it on the host the test
+// server runs commands on.
+func deliveredEnvFile(t *testing.T, srv *testServer) string {
+	t.Helper()
+
+	for _, line := range srv.recordedExecs() {
+		if m := envFilePattern.FindString(line); m != "" {
+			return m
+		}
+	}
+
+	t.Fatal("no delivery file appears in the recorded execs")
+
+	return ""
+}
+
+// TestFileEnvRouteDeliversAndCleansUp runs the file-based delivery route
+// end to end against a server that refuses env requests — the stock
+// sshd posture — and holds it to both halves of its promise: the value
+// arrives, and the file is gone before the command runs.
+func TestFileEnvRouteDeliversAndCleansUp(t *testing.T) {
+	t.Parallel()
+
+	const secret = "file-route-value"
+
+	srv := startTestServer(t, withRefusedEnv())
+	env := dialServer(t, srv)
+
+	cmd := invoke.New("printenv", "TOKEN")
+	cmd.Env = []string{"TOKEN=" + secret}
+
+	out, result, err := runOutput(t, env, cmd)
+	require.NoError(t, err)
+	require.Equal(t, 0, result.ExitCode, "the variable did not reach the command")
+	assert.Equal(t, secret, strings.TrimSpace(out), "the variable did not reach the command")
+
+	_, statErr := os.Stat(deliveredEnvFile(t, srv))
+	assert.True(t, os.IsNotExist(statErr),
+		"the delivery file must be gone before the command runs")
+
+	for _, line := range srv.recordedExecs() {
+		assert.NotContains(t, line, secret, "the secret appeared in a remote command line")
+	}
+}
+
+// TestFileEnvGuardReportsAnUndeliveredEnvironment pins the route's
+// failure half. When the delivery file cannot be read — a tmp cleaner
+// got there first — the command must not run without its environment,
+// and the caller must hear a delivery failure rather than a verdict
+// from a command that never started.
+func TestFileEnvGuardReportsAnUndeliveredEnvironment(t *testing.T) {
+	t.Parallel()
+
+	srv := startTestServer(t, withRefusedEnv(), withSabotagedEnvFile())
+	env := dialServer(t, srv)
+
+	marker := filepath.Join(t.TempDir(), "ran")
+
+	cmd := invoke.New("touch", marker)
+	cmd.Env = []string{"TOKEN=never-delivered"}
+
+	_, _, err := runOutput(t, env, cmd)
+	require.Error(t, err, "an undelivered environment must not read as success")
+
+	var transportErr *invoke.TransportError
+
+	assert.ErrorAs(t, err, &transportErr,
+		"the command never ran, so the failure is retryable transport, not a verdict")
+
+	var exitErr *invoke.ExitError
+
+	assert.NotErrorAs(t, err, &exitErr,
+		"a delivery failure must not be dressed as the command's own exit")
+
+	_, statErr := os.Stat(marker)
+	assert.True(t, os.IsNotExist(statErr),
+		"the command ran without the environment it was promised")
+}
+
+// TestExitStatusReservedByTheGuardStaysAnExitElsewhere pins the
+// reservation's scope: only the file route reads exit 93 as a delivery
+// failure. A command exiting 93 without one is its own verdict.
+func TestExitStatusReservedByTheGuardStaysAnExitElsewhere(t *testing.T) {
+	t.Parallel()
+
+	srv := startTestServer(t)
+	env := dialServer(t, srv)
+
+	_, result, err := runOutput(t, env, invoke.Shell("exit 93"))
+
+	var exitErr *invoke.ExitError
+
+	require.ErrorAs(t, err, &exitErr, "exit 93 without file delivery is the command's own")
+	assert.Equal(t, 93, exitErr.Code)
+	assert.Equal(t, 93, result.ExitCode)
+}
+
+// TestFileEnvIsRemovedWhenTheCommandCannotStart pins the orphan half:
+// a delivery file written for a command whose exec the server then
+// refuses must not outlive the failure.
+func TestFileEnvIsRemovedWhenTheCommandCannotStart(t *testing.T) {
+	t.Parallel()
+
+	srv := startTestServer(t, withRefusedEnv(), withRefusedEnvCommandExec())
+	env := dialServer(t, srv)
+
+	cmd := invoke.New("true")
+	cmd.Env = []string{"TOKEN=orphaned"}
+
+	proc, err := env.Start(t.Context(), cmd, invoke.IO{})
+	if err == nil {
+		_ = proc.Close()
+
+		require.Fail(t, "the server refused the exec; Start cannot have succeeded")
+	}
+
+	var transportErr *invoke.TransportError
+
+	assert.ErrorAs(t, err, &transportErr, "a refused exec is the transport's failure")
+
+	_, statErr := os.Stat(deliveredEnvFile(t, srv))
+	assert.True(t, os.IsNotExist(statErr),
+		"values the caller deemed too sensitive for an argv must not persist in /tmp")
+}

--- a/ssh/options.go
+++ b/ssh/options.go
@@ -129,11 +129,13 @@ func WithTimeout(d time.Duration) Option {
 // remote command line when the server refuses to accept them out of band.
 //
 // A server accepts only the variables its AcceptEnv setting names, and
-// the stock setting names none. Without this option a refusal fails the
-// command rather than running it without its environment. With it, the
-// refused variables are exported on the command line — where they appear
-// in the remote process table and every account on the host can read
-// them. Do not use it to pass secrets.
+// the stock setting names none. Refused variables ordinarily travel in a
+// file only the login user can read, which the command line sources and
+// deletes before the command runs; that route needs a writable /tmp, and
+// reserves exit status 93 to report a file that could not be read. With
+// this option the refused variables are exported on the command line
+// instead — where they appear in the remote process table and every
+// account on the host can read them. Do not use it to pass secrets.
 func WithCommandLineEnv() Option {
 	return func(c *Config) { c.CommandLineEnv = true }
 }

--- a/ssh/process.go
+++ b/ssh/process.go
@@ -20,6 +20,10 @@ type process struct {
 	session *ssh.Session
 	started time.Time
 
+	// envFile is the delivery file the command's prologue sources, when
+	// the file route is in use; empty otherwise.
+	envFile string
+
 	closedByUser atomic.Bool
 	ctxErr       func() error
 
@@ -61,7 +65,7 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 		return nil, err
 	}
 
-	prologue, err := e.deliverEnv(ctx, session, cmd.Env)
+	prologue, envFile, err := e.deliverEnv(ctx, session, cmd.Env)
 	if err != nil {
 		_ = session.Close()
 
@@ -81,12 +85,20 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 		env:     e,
 		session: session,
 		started: time.Now(),
+		envFile: envFile,
 		ctxErr:  ctx.Err,
 		done:    make(chan struct{}),
 	}
 
 	if err := session.Start(commandLine(cmd, prologue)); err != nil {
 		_ = session.Close()
+
+		// The delivery file was written for a command that never
+		// started, so nothing ahead will remove it.
+		if envFile != "" {
+			//nolint:contextcheck // Cleanup is detached by design; see removeRemoteFile.
+			e.removeRemoteFile(envFile)
+		}
 
 		return nil, &invoke.TransportError{Op: "start", Err: err}
 	}
@@ -174,7 +186,7 @@ const (
 // command. The values never reach an argument vector. A caller who cannot
 // use a file — a read-only target, say — can opt into carrying them on the
 // command line instead, where every account on the host can read them.
-func (e *Environment) deliverEnv(ctx context.Context, session *ssh.Session, env []string) (string, error) {
+func (e *Environment) deliverEnv(ctx context.Context, session *ssh.Session, env []string) (string, string, error) {
 	var refused []string
 
 	for _, pair := range env {
@@ -189,29 +201,45 @@ func (e *Environment) deliverEnv(ctx context.Context, session *ssh.Session, env 
 	}
 
 	if len(refused) == 0 {
-		return "", nil
+		return "", "", nil
 	}
 
 	if e.cfg.CommandLineEnv {
-		return exportPrologue(refused), nil
+		return exportPrologue(refused), "", nil
 	}
 
 	suffix, err := randomSuffix()
 	if err != nil {
-		return "", fmt.Errorf("ssh: start: %w", err)
+		return "", "", fmt.Errorf("ssh: start: %w", err)
 	}
 
 	path := "/tmp/.invoke-env-" + suffix
 
 	if err := e.writeRemoteFile(ctx, path, exportScript(refused)); err != nil {
-		return "", fmt.Errorf(
+		return "", "", fmt.Errorf(
 			"ssh: start: the server refused %s and they could not be delivered by file either; "+
 				"pass WithCommandLineEnv to send them on the command line, where every account "+
 				"on the host can read them: %w",
 			strings.Join(refusedNames(refused), ", "), err)
 	}
 
-	return sourcePrologue(path), nil
+	return sourcePrologue(path), path, nil
+}
+
+// cleanupTimeout bounds the best-effort removal of a delivery file.
+const cleanupTimeout = 10 * time.Second
+
+// removeRemoteFile deletes a file this package created, best effort and
+// detached from any caller context: the outcome the file supported has
+// already been decided, and a secret left in /tmp is worth one more
+// round trip.
+func (e *Environment) removeRemoteFile(path string) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), cleanupTimeout)
+	defer cancel()
+
+	if _, _, err := e.runRaw(ctx, "rm -f "+quoteArg(path)); err != nil {
+		return // Best effort: the outcome the file supported is already decided.
+	}
 }
 
 // refusedNames lists the variable names from KEY=VALUE pairs, so an error
@@ -318,6 +346,25 @@ func (p *process) doWait() {
 	p.result, p.waitErr = p.mapOutcome(err, duration)
 
 	_ = p.session.Close()
+
+	p.sweepEnvFile()
+}
+
+// sweepEnvFile removes the delivery file after an ending that may have
+// killed the shell before its own rm ran. An outcome saying the command
+// ran means the file is already gone — the prologue removes it before
+// the command — so only the other endings are swept.
+func (p *process) sweepEnvFile() {
+	if p.envFile == "" || p.waitErr == nil {
+		return
+	}
+
+	var exitErr *invoke.ExitError
+	if errors.As(p.waitErr, &exitErr) {
+		return
+	}
+
+	p.env.removeRemoteFile(p.envFile)
 }
 
 // monitorContext kills the remote command when the start context is
@@ -352,6 +399,18 @@ func (p *process) mapOutcome(err error, duration time.Duration) (invoke.Result, 
 	sig, signaled := waitSignal(err)
 
 	if !signaled {
+		// The guard's status is reserved on the file route: it says the
+		// environment file could not be read, so the command was never
+		// started — which is precisely what makes the failure safe to
+		// retry.
+		if p.envFile != "" && reportedStatus(err) == envDeliveryFailed {
+			return invoke.Result{ExitCode: -1, Duration: duration}, &invoke.TransportError{
+				Op: "env",
+				Err: errors.New(
+					"the environment file could not be read before the command ran, so the command was not started"),
+			}
+		}
+
 		if res, outcome, reported := reportedExit(err, duration); reported {
 			return res, outcome
 		}
@@ -413,6 +472,17 @@ func waitSignal(err error) (invoke.Signal, bool) {
 	}
 
 	return invoke.Signal(sig), true
+}
+
+// reportedStatus returns the exit status a session-wait error carries,
+// or -1 when it carries none.
+func reportedStatus(err error) int {
+	var exitErr *ssh.ExitError
+	if !errors.As(err, &exitErr) {
+		return -1
+	}
+
+	return exitErr.ExitStatus()
 }
 
 // reportedExit returns the outcome for a session-wait error carrying an

--- a/ssh/testserver_test.go
+++ b/ssh/testserver_test.go
@@ -9,7 +9,9 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -43,6 +45,20 @@ type testServer struct {
 	// extraHostKey is offered alongside the primary key, so a client
 	// whose known_hosts records only one of them must ask for that one.
 	extraHostKey ssh.Signer
+
+	// refuseEnv declines every env request, as a stock sshd with no
+	// AcceptEnv configuration does — the ordinary case in the field.
+	refuseEnv bool
+
+	// sabotageEnvFile deletes any delivery file a command line names
+	// before running it, standing in for a tmp cleaner that got there
+	// first.
+	sabotageEnvFile bool
+
+	// refuseEnvCommandExec declines the exec of a command carrying a
+	// delivery-file prologue, so the file is written and its command
+	// then never starts.
+	refuseEnvCommandExec bool
 
 	mu         sync.Mutex
 	sessions   int
@@ -103,6 +119,24 @@ func withStalledSFTP() serverOption {
 
 // withExtraHostKey offers a second host key of a different type, which
 // the client will prefer unless it constrains negotiation.
+// withRefusedEnv declines every env request, which is what a stock sshd
+// does: AcceptEnv names nothing by default.
+func withRefusedEnv() serverOption {
+	return func(s *testServer) { s.refuseEnv = true }
+}
+
+// withSabotagedEnvFile deletes a delivery file named by a command line
+// just before the command runs.
+func withSabotagedEnvFile() serverOption {
+	return func(s *testServer) { s.sabotageEnvFile = true }
+}
+
+// withRefusedEnvCommandExec declines the exec of any command carrying a
+// delivery-file prologue.
+func withRefusedEnvCommandExec() serverOption {
+	return func(s *testServer) { s.refuseEnvCommandExec = true }
+}
+
 func withExtraHostKey(signer ssh.Signer) serverOption {
 	return func(s *testServer) { s.extraHostKey = signer }
 }
@@ -299,11 +333,30 @@ func (s *testServer) handleSession(channel ssh.Channel, requests <-chan *ssh.Req
 	for req := range requests {
 		switch req.Type {
 		case "env":
+			if s.refuseEnv {
+				reply(req, false)
+
+				continue
+			}
+
 			state.addEnv(req.Payload)
 			reply(req, true)
 		case "exec":
 			line := execCommand(req.Payload)
 			s.recordExec(line)
+
+			// Only the command-carrying exec is refused: its prologue
+			// starts with the readability guard. The write and any
+			// cleanup pass, so the orphan is the fix's to remove.
+			if s.refuseEnvCommandExec && strings.Contains(line, envFilePrefix) && strings.Contains(line, "[ -r ") {
+				reply(req, false)
+
+				continue
+			}
+
+			if s.sabotageEnvFile {
+				removeEnvFilesNamedIn(line)
+			}
 
 			go runExec(channel, state, line)
 
@@ -548,4 +601,18 @@ func readString(b []byte) (string, []byte) {
 	}
 
 	return string(b[4 : 4+n]), b[4+n:]
+}
+
+// envFilePrefix is the prefix every delivery file's path carries.
+const envFilePrefix = "/tmp/.invoke-env-"
+
+// envFilePattern matches a delivery file's path inside a command line.
+var envFilePattern = regexp.MustCompile(`/tmp/\.invoke-env-[0-9a-f]+`)
+
+// removeEnvFilesNamedIn deletes every delivery file a command line
+// names, standing in for a tmp cleaner racing the shell.
+func removeEnvFilesNamedIn(line string) {
+	for _, path := range envFilePattern.FindAllString(line, -1) {
+		_ = os.Remove(path)
+	}
 }


### PR DESCRIPTION
## What

Three repairs to the failure half of the AcceptEnv workaround (the happy path is unchanged: refused variables travel in a 0600 file the command line sources and deletes before the command runs).

- **The guard now fires.** `. file || exit 93` could never take the `||` branch on a POSIX-mode shell: `.` is a special built-in, and its failure aborts the shell outright — a vanished file surfaced as a bare `ExitError{1}` attributed to a command that never ran. The readability test now precedes the source on its own: `[ -r file ] || exit 93; . file; rm -f file; …`.
- **The status is mapped, and reserved.** On the file route, exit 93 is read as a delivery failure and classified as a retryable `TransportError{Op: "env"}` — the command was not started, which is exactly what makes retrying safe. The reservation is scoped and documented (constant doc + `WithCommandLineEnv`, whose stale "a refusal fails the command" text is also corrected): a command exiting 93 *without* file delivery keeps its own verdict, pinned by a control test.
- **No orphaned secrets.** The file was orphaned whenever the shell died before its `rm`: a refused/failed `session.Start` now removes it on the spot, and any outcome without a reported exit (kill, severed connection, the guard itself) sweeps it best-effort after `Wait` settles.

## Test server

Three new options make all of this provable in the default lane: `withRefusedEnv` (the stock sshd posture — the file route now runs end to end in `just check`, not only behind the `openssh` tag), `withSabotagedEnvFile` (a tmp cleaner beating the shell to the file), and `withRefusedEnvCommandExec` (the file written, its command never starting).

## Verification

- Tests first: the guard case (was a bare exit, must be transport + command-never-ran via a marker file) and the orphan case (file must not survive a refused exec) were red; the happy file route (delivers, file gone before the command, value absent from every recorded exec line) and the 93-scope control were green and stay green.
- One harness bug caught mid-way: the refuse-exec option initially also refused the *cleanup* exec; it now refuses only the prologue-carrying command line, so the orphan is genuinely the fix's to remove.
- `just check` green; the `openssh` lane against a real sshd green under `-race` — the route's behavior there is unchanged and still covered by the existing tagged tests.