### PR TITLE
fix(ssh): Bound keepalive probes and honor cancellation mid-handshake

### DIFF
--- a/ssh/connection_test.go
+++ b/ssh/connection_test.go
@@ -9,9 +9,11 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/ruffel/invoke"
 	"github.com/ruffel/invoke/ssh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -237,4 +239,144 @@ func TestConstructionHonoursItsContext(t *testing.T) {
 	)
 	require.Error(t, err, "construction with a canceled context must fail")
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestConnectHonorsCancellationMidHandshake pins New's promise that ctx
+// bounds establishing the connection — including the handshake, where a
+// server that accepts the socket and then says nothing would otherwise
+// hold the caller for the full configured timeout.
+func TestConnectHonorsCancellationMidHandshake(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0") //nolint:noctx // Test listener.
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = listener.Close() })
+
+	var (
+		connsMu sync.Mutex
+		conns   []net.Conn
+	)
+
+	// Accept and say nothing, holding every socket open.
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+
+			connsMu.Lock()
+
+			conns = append(conns, conn)
+
+			connsMu.Unlock()
+		}
+	}()
+
+	t.Cleanup(func() {
+		connsMu.Lock()
+		defer connsMu.Unlock()
+
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+	})
+
+	host, portText, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	const bound = 10 * time.Second
+
+	began := time.Now()
+
+	_, err = ssh.New(ctx, host,
+		ssh.WithPort(port),
+		ssh.WithUser("tester"),
+		ssh.WithPassword(testPassword),
+		ssh.WithInsecureIgnoreHostKey())
+	require.Error(t, err, "a canceled setup must not connect")
+
+	assert.ErrorIs(t, err, context.Canceled,
+		"the caller's own cancellation is the cause worth reporting")
+
+	assert.Less(t, time.Since(began), bound,
+		"cancellation must interrupt the handshake, not wait out its timeout")
+}
+
+// TestBlackholedConnectionUnblocksWaitAndClose pins what the keepalive
+// exists for. A link that dies silently — no reset, no close — answers
+// nothing; a probe unanswered within one interval must declare the
+// connection dead and close it, unblocking a running Wait with an
+// honest no-status outcome and letting Close return instead of waiting
+// on a socket nobody serves.
+func TestBlackholedConnectionUnblocksWaitAndClose(t *testing.T) {
+	t.Parallel()
+
+	const (
+		probeInterval = 100 * time.Millisecond
+		bound         = 8 * time.Second
+	)
+
+	srv := startTestServer(t)
+
+	env, err := ssh.New(t.Context(), srv.host(),
+		ssh.WithPort(srv.port()),
+		ssh.WithUser("tester"),
+		ssh.WithPassword(testPassword),
+		ssh.WithHostKeyCallback(xssh.FixedHostKey(srv.hostKey)),
+		ssh.WithKeepAlive(probeInterval))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	proc, err := env.Start(t.Context(), invoke.New("sleep", "30"), invoke.IO{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = proc.Close() })
+
+	srv.blackholeNow()
+
+	waited := make(chan error, 1)
+
+	go func() {
+		_, waitErr := proc.Wait()
+		waited <- waitErr
+	}()
+
+	select {
+	case waitErr := <-waited:
+		require.Error(t, waitErr, "a dead link cannot end in a reported success")
+
+		var exitErr *invoke.ExitError
+
+		assert.NotErrorAs(t, waitErr, &exitErr,
+			"no status arrived; the outcome must not read as the command's own exit")
+	case <-time.After(bound):
+		t.Fatal("Wait did not return: the dead link was never discovered")
+	}
+
+	closed := make(chan struct{})
+
+	go func() {
+		_ = env.Close()
+
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(bound):
+		t.Fatal("Close did not return on a blackholed connection")
+	}
 }

--- a/ssh/environment.go
+++ b/ssh/environment.go
@@ -136,11 +136,33 @@ func connect(ctx context.Context, cfg *Config) (*ssh.Client, io.Closer, error) {
 	// call open indefinitely.
 	_ = conn.SetDeadline(handshakeDeadline(dialCtx, cfg.timeout()))
 
+	// The deadline covers timeouts; a plain cancellation has no deadline
+	// to fire, so a watcher closes the socket — which is what unblocks a
+	// handshake in progress.
+	handshakeDone := make(chan struct{})
+
+	go func() {
+		select {
+		case <-dialCtx.Done():
+			_ = conn.Close()
+		case <-handshakeDone:
+		}
+	}()
+
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, clientCfg)
+
+	close(handshakeDone)
+
 	if err != nil {
 		_ = conn.Close()
 
 		closeAgent(agentConn)
+
+		// When the caller's own context ended the handshake, that is
+		// the cause worth reporting.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, nil, fmt.Errorf("ssh: connect: %w", ctxErr)
+		}
 
 		return nil, nil, &invoke.TransportError{Op: "handshake", Err: err}
 	}
@@ -244,7 +266,8 @@ func (e *Environment) Close() error {
 	e.mu.Unlock()
 
 	// Stop probing and wait for the loop to finish before the connection
-	// goes away, so no probe outlives Close.
+	// goes away, so no probe outlives Close. The wait is bounded: a
+	// probe already in flight answers or times out within one interval.
 	if e.stopKeepAlive != nil {
 		e.stopKeepAlive()
 		<-e.keepAliveDone
@@ -264,6 +287,13 @@ func (e *Environment) Close() error {
 // startKeepAlive probes the server periodically so a connection that dies
 // without a close — a dropped link, a NAT timeout — is discovered rather
 // than leaving the next operation blocked on a socket nobody is serving.
+//
+// A probe the server does not answer within one interval is that
+// discovery. The client is closed on the spot, which is what unblocks
+// everything still waiting on the dead link: running Waits, transfers,
+// and Close itself. Without the bound, a probe on a black-holed
+// connection would block in its own send until the kernel gave up on
+// the socket — and hold Close hostage with it.
 func (e *Environment) startKeepAlive() {
 	interval := e.cfg.keepAlive()
 	if interval <= 0 {
@@ -273,6 +303,11 @@ func (e *Environment) startKeepAlive() {
 	ctx, cancel := context.WithCancel(context.Background())
 	e.stopKeepAlive = cancel
 	e.keepAliveDone = make(chan struct{})
+
+	// The grace is how long an answer may take before the link is
+	// declared dead. It is floored: an answer bound tighter than a
+	// second measures scheduling noise, not the link.
+	grace := max(interval, probeGraceFloor)
 
 	go func() {
 		defer close(e.keepAliveDone)
@@ -285,15 +320,50 @@ func (e *Environment) startKeepAlive() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				// A failed probe means the connection is gone; the
-				// operations using it report that themselves, so the
-				// loop only needs to stop asking.
-				if _, _, err := e.client.SendRequest("keepalive@openssh.com", true, nil); err != nil {
+				if !e.probeAlive(ctx, grace) {
+					_ = e.client.Close()
+
 					return
 				}
 			}
 		}
 	}()
+}
+
+// probeGraceFloor is the least time a probe gets to answer.
+const probeGraceFloor = time.Second
+
+// probeAlive sends one keepalive and reports whether the server answered
+// within bound. An answer slower than the probing cadence is
+// indistinguishable from none; a stopped loop no longer cares either
+// way.
+func (e *Environment) probeAlive(ctx context.Context, bound time.Duration) bool {
+	answered := make(chan error, 1)
+
+	go func() {
+		_, _, err := e.client.SendRequest("keepalive@openssh.com", true, nil)
+		answered <- err
+	}()
+
+	timer := time.NewTimer(bound)
+	defer timer.Stop()
+
+	select {
+	case err := <-answered:
+		return err == nil
+	case <-timer.C:
+		return false
+	case <-ctx.Done():
+		// Stopping. Liveness no longer matters, but a probe already on
+		// the wire is seen out first — no probe outlives Close — with
+		// the same bound, so a dead link cannot hold this open either.
+		select {
+		case <-answered:
+		case <-timer.C:
+		}
+
+		return true
+	}
 }
 
 // detectOS runs uname on the remote host to classify its operating system,

--- a/ssh/options.go
+++ b/ssh/options.go
@@ -141,7 +141,12 @@ func WithCommandLineEnv() Option {
 }
 
 // WithKeepAlive sets how often the connection is probed so a silently
-// dropped link is discovered. A non-positive interval disables probing.
+// dropped link is discovered. Probing is also the discovery bound: a
+// probe unanswered within the interval — floored at one second, since a
+// tighter bound measures scheduling noise rather than the link —
+// declares the connection dead and closes it, unblocking everything
+// still waiting on it, including Close. Zero means the default; a
+// negative interval disables probing.
 func WithKeepAlive(d time.Duration) Option {
 	return func(c *Config) { c.KeepAlive = d }
 }

--- a/ssh/testserver_test.go
+++ b/ssh/testserver_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -64,6 +65,10 @@ type testServer struct {
 	// delivery-file prologue, so the file is written and its command
 	// then never starts.
 	refuseEnvCommandExec bool
+
+	// blackholed, once set, stops the server answering global requests
+	// while keeping every connection open — a link that silently died.
+	blackholed atomic.Bool
 
 	mu         sync.Mutex
 	sessions   int
@@ -152,6 +157,12 @@ func withExtraHostKey(signer ssh.Signer) serverOption {
 	return func(s *testServer) { s.extraHostKey = signer }
 }
 
+// blackholeNow makes the server stop answering global requests while
+// keeping every connection open, as a silently dead link does.
+func (s *testServer) blackholeNow() {
+	s.blackholed.Store(true)
+}
+
 // keepAliveCount reports how many keepalive probes the server answered.
 func (s *testServer) keepAliveCount() int {
 	s.mu.Lock()
@@ -164,6 +175,10 @@ func (s *testServer) keepAliveCount() int {
 // keepalive probes.
 func (s *testServer) handleGlobalRequests(reqs <-chan *ssh.Request) {
 	for req := range reqs {
+		if s.blackholed.Load() {
+			continue // Swallowed: no reply ever comes.
+		}
+
 		if req.Type == "keepalive@openssh.com" {
 			s.mu.Lock()
 			s.keepAlives++


### PR DESCRIPTION
## What

Two lifecycle holes on unhappy links:

- **A wedged probe could hang Close.** The keepalive's `SendRequest` awaited its reply unboundedly, so on a black-holed connection (no reset, no close) the probe blocked until kernel TCP gave up — and `Close`, which waits for the probing loop before touching anything else, hung behind it. Detection latency was likewise the kernel's, not the configured cadence, despite the option's ServerAliveInterval-like name.
- **Cancellation didn't reach the handshake.** After the dial, only a deadline bounded `ssh.NewClientConn`; canceling a deadline-less context mid-handshake waited out the full configured timeout (default 30s) against a server that accepts and says nothing.

Now: a probe gets one interval to answer, **floored at one second** (a tighter bound measures scheduling noise, not the link). An unanswered probe is the discovery probing exists for — the client is closed on the spot, unblocking running Waits, transfers, and Close, all within the bound. A probe already in flight when Close arrives is seen out under the same bound, preserving the existing "no probe outlives Close" guarantee. And a watcher closes the socket on mid-handshake cancellation, reporting the caller's own `context.Canceled`.

## Verification

- Tests first, both red: a server that accepts TCP and never speaks SSH held `New` for the full 30s and reported a transport error instead of `context.Canceled`; a blackholed established connection (new test-server switch that swallows global requests while keeping sockets open) left a running `Wait` and `Close` hung at an 8-second bound.
- The first design was corrected by the suite itself, twice: the loaded `openssh` lane declared a healthy 20ms-cadence link dead (hence the one-second floor) and let a scheduler-lagged probe land after Close, tripping the existing `TestKeepAliveStopsOnClose` (hence seeing an in-flight probe out). Both keepalive semantics tests now pass under load.
- `just check` green; keepalive/blackhole/handshake tests stressed `-count=3 -race`; the full `openssh` lane green under `-race` alongside real containers.