### PR TITLE
fix(ssh): Resolve names through the filesystem, and classify the answers honestly

### DIFF
--- a/ssh/classify_test.go
+++ b/ssh/classify_test.go
@@ -1,0 +1,109 @@
+package ssh_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ruffel/invoke"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPTYRefusalIsNotSupported pins the classification of a server
+// saying no to terminal allocation — PermitTTY no answers the same way
+// every time, so the refusal is a policy verdict, not a transport blip,
+// and retrying it is futile.
+func TestPTYRefusalIsNotSupported(t *testing.T) {
+	t.Parallel()
+
+	srv := startTestServer(t, withRefusedPTY())
+	env := dialServer(t, srv)
+
+	proc, err := env.Start(t.Context(), invoke.New("true"), invoke.IO{TTY: &invoke.TTY{}})
+	if err == nil {
+		_ = proc.Close()
+
+		require.Fail(t, "the server refused the terminal; Start cannot have succeeded")
+	}
+
+	assert.ErrorIs(t, err, invoke.ErrNotSupported,
+		"a refused terminal is a thing this server will not do")
+
+	var transportErr *invoke.TransportError
+
+	assert.NotErrorAs(t, err, &transportErr,
+		"a deterministic policy refusal must not classify as retryable transport")
+}
+
+// TestUnknownServerOSIsReportedUnknown pins OS() against a system the
+// package has never verified its assumptions on: not determined is the
+// honest answer, not "probably Linux".
+func TestUnknownServerOSIsReportedUnknown(t *testing.T) {
+	t.Parallel()
+
+	srv := startTestServer(t, withUnameOutput("FreeBSD"))
+	env := dialServer(t, srv)
+
+	assert.Equal(t, invoke.OSUnknown, env.OS(),
+		"an unrecognized uname must not be reported as a known system")
+}
+
+// TestLookPathReportsOnlyExecutablePaths pins LookPath to its own
+// promise: the answer is an executable path on the target. A shell
+// builtin answers command -v and is not one; an option-shaped name must
+// not be read as a flag.
+func TestLookPathReportsOnlyExecutablePaths(t *testing.T) {
+	t.Parallel()
+
+	srv := startTestServer(t)
+	env := dialServer(t, srv)
+
+	// "cd" is a builtin everywhere and a real file on some systems: the
+	// invariant is that the answer is never the bare builtin name.
+	if resolved, err := env.LookPath(t.Context(), "cd"); err == nil {
+		assert.Truef(t, strings.HasPrefix(resolved, "/"),
+			"a bare builtin name is not an executable path, got %q", resolved)
+	} else {
+		assert.ErrorIs(t, err, invoke.ErrNotFound,
+			"a builtin with no file behind it is not found")
+	}
+
+	_, err := env.LookPath(t.Context(), "-p")
+	assert.ErrorIs(t, err, invoke.ErrNotFound,
+		"an option-shaped name is a name, not a flag for the probe")
+
+	// "echo" is shadowed by a builtin in every POSIX shell and still a
+	// real executable; the file is the answer LookPath promised.
+	resolved, err := env.LookPath(t.Context(), "echo")
+	require.NoError(t, err, "a real /bin/echo must not be hidden by the builtin of the same name")
+
+	assert.True(t, strings.HasPrefix(resolved, "/"),
+		"a resolved executable is an absolute path, got %q", resolved)
+}
+
+// TestPreCheckHonorsCommandPATH pins the pre-flight check to resolving
+// the executable exactly where the command will: with the PATH the
+// caller supplied, not the login default. Diverging turns a runnable
+// command into ErrNotFound — or waves through a name that resolves to
+// something else entirely at run time.
+func TestPreCheckHonorsCommandPATH(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tool := filepath.Join(dir, "custom-tool")
+	require.NoError(t, os.WriteFile(tool, []byte("#!/bin/sh\necho from-custom-path\n"), 0o755))
+
+	srv := startTestServer(t)
+	env := dialServer(t, srv)
+
+	cmd := invoke.New("custom-tool")
+	cmd.Env = []string{"PATH=" + dir + ":/usr/bin:/bin"}
+
+	out, result, err := runOutput(t, env, cmd)
+	require.NoError(t, err, "a command resolvable through its own PATH must start")
+	require.Equal(t, 0, result.ExitCode)
+
+	assert.Equal(t, "from-custom-path", strings.TrimSpace(out))
+}

--- a/ssh/command.go
+++ b/ssh/command.go
@@ -40,6 +40,20 @@ func commandLine(cmd invoke.Command, prologue string) string {
 	return prologue + line
 }
 
+// envValue returns the last value name carries in env, honoring the
+// same last-wins rule the delivered environment has.
+func envValue(env []string, name string) (string, bool) {
+	value, found := "", false
+
+	for _, pair := range env {
+		if key, v, ok := strings.Cut(pair, "="); ok && key == name {
+			value, found = v, true
+		}
+	}
+
+	return value, found
+}
+
 // exportScript renders KEY=VALUE pairs as a shell script that exports
 // them, for a file the command line sources.
 func exportScript(pairs []string) string {
@@ -115,21 +129,60 @@ const (
 func preCheckLine(cmd invoke.Command) string {
 	var b strings.Builder
 
+	// The check resolves the executable exactly where the command will:
+	// a PATH the caller supplies travels into the pre-check, or the two
+	// disagree — refusing a runnable command, or waving through a name
+	// that resolves elsewhere at run time. PATH is no secret; the
+	// values that stay off command lines travel by the env machinery.
+	if value, ok := envValue(cmd.Env, "PATH"); ok {
+		b.WriteString("PATH=" + quoteArg(value) + "; export PATH; ")
+	}
+
 	if cmd.Dir != "" {
 		b.WriteString("cd " + quoteArg(cmd.Dir) + " 2>/dev/null")
 		b.WriteString(" || exit " + strconv.Itoa(preCheckBadDir) + "; ")
 	}
 
-	// A name is resolved through PATH, which only ever yields something
-	// executable. A path is checked directly, because "command -v" given
-	// a path answers whether the file exists on some shells and whether
-	// it can be executed on others — and the first answer would let a
-	// file that cannot run reach the caller as a runtime failure instead.
+	// A name is resolved by walking PATH for executable files, exactly
+	// as every other provider resolves one. A path is checked directly,
+	// because "command -v" given a path answers whether the file exists
+	// on some shells and whether it can be executed on others — and the
+	// first answer would let a file that cannot run reach the caller as
+	// a runtime failure instead.
 	b.WriteString("case " + quoteArg(cmd.Path) + " in ")
 	b.WriteString("*/*) [ -f " + quoteArg(cmd.Path) + " ] && [ -x " + quoteArg(cmd.Path) + " ]")
 	b.WriteString(" || exit " + strconv.Itoa(preCheckNotFound) + " ;; ")
-	b.WriteString("*) command -v " + quoteArg(cmd.Path) + " >/dev/null 2>&1")
-	b.WriteString(" || exit " + strconv.Itoa(preCheckNotFound) + " ;; ")
+	b.WriteString("*) " + pathWalkLine(quoteArg(cmd.Path), "exit 0", "exit "+strconv.Itoa(preCheckNotFound)) + " ;; ")
+	b.WriteString("esac")
+
+	return b.String()
+}
+
+// pathWalkLine walks the login PATH for the already-quoted name, files
+// only, running hit on the first match and miss when nothing matched.
+//
+// The walk is what keeps resolution honest: "command -v" answers for
+// shell builtins and keywords too, so it blesses a bare "cd" that no
+// exec could ever run, and it shadows a real /bin/echo behind the
+// builtin of the same name. Every other provider resolves through the
+// filesystem; this is the same search spelled in sh.
+func pathWalkLine(quoted, hit, miss string) string {
+	probe := `[ -f "$d/"` + quoted + ` ] && [ -x "$d/"` + quoted + ` ]`
+
+	return "IFS=:; for d in $PATH; do " + probe + " && { " + hit + "; }; done; " + miss
+}
+
+// lookPathLine resolves a name the way the local provider's LookPath
+// does: a name containing a slash is checked directly; a bare name
+// walks the login PATH and prints the first executable file it finds.
+func lookPathLine(name string) string {
+	quoted := quoteArg(name)
+
+	var b strings.Builder
+
+	b.WriteString("case " + quoted + " in ")
+	b.WriteString("*/*) [ -f " + quoted + " ] && [ -x " + quoted + " ] && printf '%s\\n' " + quoted + " ;; ")
+	b.WriteString("*) " + pathWalkLine(quoted, `printf '%s\n' "$d/"`+quoted+"; exit 0", "exit 1") + " ;; ")
 	b.WriteString("esac")
 
 	return b.String()

--- a/ssh/environment.go
+++ b/ssh/environment.go
@@ -5,9 +5,11 @@
 // Commands are delivered to the remote login shell as a single, shell-safe
 // command line (the SSH protocol carries a command string, not an argv),
 // with environment variables sent out of band so they do not appear in the
-// remote process table. Host-key verification is fail-closed: a connection
-// requires known_hosts, an explicit callback, or an explicit insecure
-// override.
+// remote process table. The login shell is assumed POSIX-compatible:
+// command lines, pre-flight checks, and environment prologues are plain
+// sh, and a csh-family login shell will misread them. Host-key
+// verification is fail-closed: a connection requires known_hosts, an
+// explicit callback, or an explicit insecure override.
 package ssh
 
 import (
@@ -203,8 +205,11 @@ func (e *Environment) OS() invoke.TargetOS {
 }
 
 // Capabilities reports the SSH target's optional features. Terminal
-// allocation is available, the protocol carrying a pseudo-terminal
-// request natively, and SFTP preserves symbolic links.
+// allocation is available — the protocol carries a pseudo-terminal
+// request natively, though a server configured with PermitTTY no
+// refuses it, and that refusal is reported wrapping
+// [invoke.ErrNotSupported] rather than retried. SFTP preserves symbolic
+// links.
 //
 // Signal delivery is declared with a caveat this provider cannot resolve
 // for itself. The protocol carries a signal request, and the servers this
@@ -234,7 +239,7 @@ func (e *Environment) LookPath(ctx context.Context, name string) (string, error)
 		return "", err
 	}
 
-	out, code, err := e.runRaw(ctx, "command -v "+quoteArg(name))
+	out, code, err := e.runRaw(ctx, lookPathLine(name))
 	if err != nil {
 		return "", fmt.Errorf("ssh: lookpath %q: %w", name, err)
 	}
@@ -366,15 +371,17 @@ func (e *Environment) probeAlive(ctx context.Context, bound time.Duration) bool 
 	}
 }
 
-// detectOS runs uname on the remote host to classify its operating system,
-// defaulting to Linux when the answer is unrecognized.
+// detectOS runs uname on the remote host to classify its operating
+// system. A system it does not recognize — or a probe that fails — is
+// reported as undetermined: "probably Linux" is a guess, and the
+// taxonomy has an honest value for not knowing.
 func (e *Environment) detectOS(ctx context.Context) invoke.TargetOS {
 	probeCtx, cancel := context.WithTimeout(ctx, e.cfg.timeout())
 	defer cancel()
 
 	out, code, err := e.runRaw(probeCtx, "uname -s")
 	if err != nil || code != 0 {
-		return invoke.OSLinux
+		return invoke.OSUnknown
 	}
 
 	switch strings.TrimSpace(out) {
@@ -383,7 +390,7 @@ func (e *Environment) detectOS(ctx context.Context) invoke.TargetOS {
 	case "Linux":
 		return invoke.OSLinux
 	default:
-		return invoke.OSLinux
+		return invoke.OSUnknown
 	}
 }
 

--- a/ssh/process.go
+++ b/ssh/process.go
@@ -155,6 +155,15 @@ func requestPTY(session *ssh.Session, tty *invoke.TTY) error {
 	}
 
 	if err := session.RequestPty(defaultTerm, rows, cols, modes); err != nil {
+		// The library reports the server's refusal and a transport
+		// failure through the same call, distinguishable only by its
+		// refusal sentinel. A refusal — PermitTTY no — answers the same
+		// way every time; classifying it as transport invites futile
+		// retries of a policy verdict.
+		if err.Error() == "ssh: pty-req failed" {
+			return fmt.Errorf("ssh: start: the server refused terminal allocation: %w", invoke.ErrNotSupported)
+		}
+
 		return &invoke.TransportError{Op: "pty", Err: err}
 	}
 

--- a/ssh/testserver_test.go
+++ b/ssh/testserver_test.go
@@ -52,6 +52,13 @@ type testServer struct {
 	// AcceptEnv configuration does — the ordinary case in the field.
 	refuseEnv bool
 
+	// refusePTY declines pty-req, as a server with PermitTTY no does.
+	refusePTY bool
+
+	// unameOutput, when set, answers a uname probe with this text
+	// instead of the host's own answer.
+	unameOutput string
+
 	// authorizedKey, when set, is accepted for public-key
 	// authentication alongside the password.
 	authorizedKey ssh.PublicKey
@@ -133,6 +140,17 @@ func withStalledSFTP() serverOption {
 // alongside the password.
 func withAuthorizedKey(pub ssh.PublicKey) serverOption {
 	return func(s *testServer) { s.authorizedKey = pub }
+}
+
+// withRefusedPTY declines pty-req, as a server with PermitTTY no does.
+func withRefusedPTY() serverOption {
+	return func(s *testServer) { s.refusePTY = true }
+}
+
+// withUnameOutput answers a uname probe with the given text, standing
+// in for a server whose operating system this package has never met.
+func withUnameOutput(out string) serverOption {
+	return func(s *testServer) { s.unameOutput = out }
 }
 
 // withRefusedEnv declines every env request, which is what a stock sshd
@@ -394,10 +412,22 @@ func (s *testServer) handleSession(channel ssh.Channel, requests <-chan *ssh.Req
 				removeEnvFilesNamedIn(line)
 			}
 
+			if s.unameOutput != "" && strings.Contains(line, "uname") {
+				// The probe runs a real command either way; only the
+				// answer is staged.
+				line = "echo " + s.unameOutput
+			}
+
 			go runExec(channel, state, line)
 
 			reply(req, true)
 		case "pty-req":
+			if s.refusePTY {
+				reply(req, false)
+
+				continue
+			}
+
 			state.pty = true
 
 			reply(req, true)


### PR DESCRIPTION
## What

Four repairs with one thread — a guess where there was a verdict, or a verdict where there was a guess:

- **Name resolution walks PATH for executable files**, the same search every other provider runs. `LookPath` and the pre-flight check leaned on `command -v`, which answers for builtins and keywords too: `LookPath("cd")` returned a bare name no exec could run, `LookPath("-p")` returned `("", nil)`, a real `/bin/echo` was reachable only as the builtin's name, and the pre-check blessed builtins through to a runtime 127. The walk (`case` for slash-paths, files-only PATH loop for bare names) fixes all four shapes at once.
- **The pre-check resolves with the caller's PATH.** A `Command.Env` carrying `PATH=…` reached execution but not the pre-check, which refused runnable commands with `ErrNotFound` (PATH is no secret; the values that stay off command lines travel by the env machinery).
- **A PTY refusal is `ErrNotSupported`, not retryable transport.** `PermitTTY no` answers identically every time; the refusal is distinguished from a genuine transport failure by x/crypto's refusal sentinel, and the `Capabilities` doc now carries the caveat the way the Signals one always has.
- **An unrecognized `uname` is `OSUnknown`**, the taxonomy's value for not knowing — not "probably Linux".

The package doc also states the POSIX-shell assumption everything rides on.

## Interesting middle

My first fix for LookPath was an absolute-path guard over `command -v` — and the new test's own control case caught it demoting `echo` (builtin in every POSIX sh *and* a real binary) to `ErrNotFound`. The filesystem walk is what the promise actually requires; the test now pins both directions (bare builtins never returned; shadowed real binaries still found).

## Verification

- Four tests first, all red: PTY refusal classified as transport, FreeBSD `uname` reported as Linux (new `withUnameOutput` server option), builtin/flag-shaped LookPath answers, and a custom-PATH command refused at pre-check (new `withRefusedPTY` option for the first).
- All green after; `just check` green; the `openssh` lane — where the walk runs inside a real login shell — green under `-race`.