### PR TITLE
fix(local): Close the terminal's command end when Start fails

### DIFF
--- a/local/process.go
+++ b/local/process.go
@@ -115,7 +115,7 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 	}
 
 	if p.term != nil {
-		p.term.start(execCmd, stdio)
+		p.term.start(stdio)
 	}
 
 	if p.stdinR != nil {

--- a/local/pty_leak_test.go
+++ b/local/pty_leak_test.go
@@ -1,0 +1,73 @@
+//go:build unix
+
+package local_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ruffel/invoke"
+	"github.com/ruffel/invoke/local"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openFDs counts this process's open file descriptors. Readdirnames
+// never stats, which matters on darwin: devfs reports no entry types,
+// and a stat fallback trips over the directory handle's own descriptor.
+func openFDs(t *testing.T) int {
+	t.Helper()
+
+	dir, err := os.Open("/dev/fd")
+	require.NoError(t, err, "counting descriptors")
+
+	defer func() { _ = dir.Close() }()
+
+	names, err := dir.Readdirnames(-1)
+	require.NoError(t, err, "counting descriptors")
+
+	return len(names)
+}
+
+// TestFailedTTYStartLeaksNoDescriptors pins the cleanup of a terminal
+// whose command never ran. The exec package does not close
+// caller-supplied files when Start fails, so the command's end of the
+// terminal is still this side's to release — a retry loop against a
+// missing binary would otherwise bleed a descriptor per attempt until
+// a garbage collection happened to notice.
+//
+// The test stays serial: it counts the process's descriptors, and a
+// parallel test opening files would count too.
+//
+//nolint:paralleltest // Descriptor counting needs the process to itself.
+func TestFailedTTYStartLeaksNoDescriptors(t *testing.T) {
+	env, err := local.New()
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	startOnce := func() {
+		t.Helper()
+
+		proc, startErr := env.Start(t.Context(), invoke.New("/nonexistent/tool"), invoke.IO{TTY: &invoke.TTY{}})
+		if startErr == nil {
+			_ = proc.Close()
+
+			require.Fail(t, "the binary does not exist; Start cannot succeed")
+		}
+	}
+
+	// One warm-up start, so lazy initialization is not counted.
+	startOnce()
+
+	before := openFDs(t)
+
+	const attempts = 10
+
+	for range attempts {
+		startOnce()
+	}
+
+	assert.Equal(t, before, openFDs(t),
+		"failed TTY starts must release both ends of the terminal")
+}

--- a/local/pty_unix.go
+++ b/local/pty_unix.go
@@ -15,10 +15,14 @@ import (
 )
 
 // terminal is the caller's end of a pseudo-terminal, and the goroutines
-// moving bytes across it.
+// moving bytes across it. It holds the command's end too until the
+// command is running: the exec package does not close caller-supplied
+// files when Start fails, so until then the descriptor is this side's
+// to release.
 type terminal struct {
-	primary *os.File
-	copied  chan struct{}
+	primary   *os.File
+	secondary *os.File
+	copied    chan struct{}
 }
 
 // attachTerminal gives cmd a pseudo-terminal of the requested size and
@@ -56,7 +60,7 @@ func attachTerminal(cmd *exec.Cmd, requested *invoke.TTY) (*terminal, error) {
 	cmd.Stderr = secondary
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true}
 
-	return &terminal{primary: primary, copied: make(chan struct{})}, nil
+	return &terminal{primary: primary, secondary: secondary, copied: make(chan struct{})}, nil
 }
 
 // start begins moving bytes once the command is running, and releases the
@@ -65,10 +69,9 @@ func attachTerminal(cmd *exec.Cmd, requested *invoke.TTY) (*terminal, error) {
 // The parent must let go of that end: while any handle to it remains
 // open, reading the caller's end blocks forever rather than reporting
 // that the command has finished with it.
-func (t *terminal) start(cmd *exec.Cmd, stdio invoke.IO) {
-	if secondary, ok := cmd.Stdin.(*os.File); ok {
-		_ = secondary.Close()
-	}
+func (t *terminal) start(stdio invoke.IO) {
+	_ = t.secondary.Close()
+	t.secondary = nil
 
 	if stdio.Stdin != nil {
 		go func() {
@@ -103,8 +106,12 @@ func (t *terminal) finish(grace time.Duration) {
 	_ = t.primary.Close()
 }
 
-// close releases the caller's end without waiting, for a command that
-// never started.
+// close releases both ends without waiting, for a command that never
+// started and so never took ownership of its own end.
 func (t *terminal) close() {
+	if t.secondary != nil {
+		_ = t.secondary.Close()
+	}
+
 	_ = t.primary.Close()
 }

--- a/local/pty_windows.go
+++ b/local/pty_windows.go
@@ -20,7 +20,7 @@ func attachTerminal(_ *exec.Cmd, _ *invoke.TTY) (*terminal, error) {
 	return nil, fmt.Errorf("local: start: tty allocation: %w", invoke.ErrNotSupported)
 }
 
-func (t *terminal) start(_ *exec.Cmd, _ invoke.IO) {}
+func (t *terminal) start(_ invoke.IO) {}
 
 func (t *terminal) finish(_ time.Duration) {}
 


### PR DESCRIPTION
## What

A failed `Start` with a TTY leaked the command's end of the pseudo-terminal. `terminal.close()` released only the caller's end (`primary`); the command's end sat in `cmd.Stdin/Stdout/Stderr`, and os/exec does not close caller-supplied `*os.File`s when `Start` fails. A retry loop against a missing binary bled one descriptor per attempt until a GC happened to finalize the `os.File`.

The `terminal` now holds its `secondary` until the command is running: the success path closes it exactly as before (the parent must let go for EOF to be observable) and nils it; the never-started path closes both ends. The Windows stub signature follows — caught by the cross-build gate.

## Verification

- Descriptor-counting test written first: warm-up start, baseline, ten failed TTY starts — red with exactly the leak (+10), green after, `-count=3` under `-race`. The test is deliberately serial (a parallel test opening files would count too) and counts via `Readdirnames`, since darwin's devfs reports no entry types and `os.ReadDir`'s stat fallback trips over the directory handle's own descriptor.
- `just check` green, including the Windows cross-build.