### PR TITLE
fix(local): Join the terminal's copier before Wait returns

### DIFF
--- a/local/pty_finish_test.go
+++ b/local/pty_finish_test.go
@@ -1,0 +1,104 @@
+//go:build unix
+
+package local_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ruffel/invoke"
+	"github.com/ruffel/invoke/local"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// heldWriter reports its first write and then holds it until released,
+// keeping the output copier inside the caller's writer for as long as
+// the test needs.
+type heldWriter struct {
+	started     chan struct{}
+	held        chan struct{}
+	startOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newHeldWriter() *heldWriter {
+	return &heldWriter{started: make(chan struct{}), held: make(chan struct{})}
+}
+
+func (w *heldWriter) Write(p []byte) (int, error) {
+	w.startOnce.Do(func() { close(w.started) })
+
+	<-w.held
+
+	return len(p), nil
+}
+
+func (w *heldWriter) release() {
+	w.releaseOnce.Do(func() { close(w.held) })
+}
+
+// TestTTYWaitJoinsTheCopier pins the boundary Wait draws under a
+// terminal: once it returns, the caller's buffers are the caller's
+// again. The grace period bounds how long an exited command's output is
+// awaited — it must not bound the copier's last write. A Wait that
+// returns while the copier is still inside the caller's writer leaves
+// that write to land whenever the writer yields, racing whatever the
+// caller does next with its own buffer. The non-terminal path already
+// guarantees the join; this pins the terminal path to the same rule.
+func TestTTYWaitJoinsTheCopier(t *testing.T) {
+	t.Parallel()
+
+	const (
+		grace       = 100 * time.Millisecond
+		observation = 600 * time.Millisecond
+		bound       = 5 * time.Second
+	)
+
+	env, err := local.New(local.WithTerminationGrace(grace))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	writer := newHeldWriter()
+
+	t.Cleanup(writer.release)
+
+	proc, err := env.Start(t.Context(), invoke.Shell("echo held"),
+		invoke.IO{TTY: &invoke.TTY{}, Stdout: writer})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = proc.Close() })
+
+	select {
+	case <-writer.started:
+	case <-time.After(bound):
+		t.Fatal("the command's output never reached the caller's writer")
+	}
+
+	waited := make(chan error, 1)
+
+	go func() {
+		_, waitErr := proc.Wait()
+		waited <- waitErr
+	}()
+
+	// The command has exited and the grace has long expired; the copier
+	// is still inside the caller's Write. Wait must be waiting with it.
+	select {
+	case <-waited:
+		t.Fatal("Wait returned while the copier was still inside the caller's writer; " +
+			"its write would land after the buffers went back to the caller")
+	case <-time.After(observation):
+	}
+
+	writer.release()
+
+	select {
+	case waitErr := <-waited:
+		assert.NoError(t, waitErr, "the command exited 0; the held drain must not rewrite that")
+	case <-time.After(bound):
+		t.Fatal("Wait did not return after the writer was released")
+	}
+}

--- a/local/pty_unix.go
+++ b/local/pty_unix.go
@@ -97,6 +97,13 @@ func (t *terminal) start(stdio invoke.IO) {
 // A terminal ends when nothing holds it open, and something the command
 // left behind can hold it open indefinitely, so the wait is bounded and
 // the end is released either way — which unblocks any copy still on it.
+//
+// Released, and then joined: the copier may hold bytes it read just
+// before the release, and its last write must land before Wait returns,
+// because after that the buffers belong to the caller again. The close
+// is what unblocks a copier still mid-read, so the join cannot wait on
+// the terminal — only on the caller's own writer, exactly as the
+// non-terminal path waits on it.
 func (t *terminal) finish(grace time.Duration) {
 	select {
 	case <-t.copied:
@@ -104,6 +111,8 @@ func (t *terminal) finish(grace time.Duration) {
 	}
 
 	_ = t.primary.Close()
+
+	<-t.copied
 }
 
 // close releases both ends without waiting, for a command that never


### PR DESCRIPTION
## What

In the TTY grace-timeout path, `Wait` could return while the output copier was still holding bytes it had read just before the terminal was released — its final `Write` then landed in the caller's buffer whenever the writer yielded, silently racing whatever the caller did next with what `Wait` had told them was theirs again. The non-terminal path never had this hole: os/exec closes its pipes and still joins its copy goroutines before `Wait` returns.

`finish` now releases the terminal and then joins the copier. The release is what unblocks a copier still mid-read, so the join cannot block on the terminal itself — only on the caller's own writer, exactly the wait the non-terminal path performs. The grace keeps bounding what it always bounded (how long an exited command's output is awaited); it no longer amputates a write in flight.

## Verification

- Test written first, deterministic in both directions: the caller's writer reports its first write and then holds it. Pre-fix, `Wait` returned while the copier was still inside that writer — red at exactly that assertion. Post-fix, `Wait` stays blocked well past the grace and returns promptly once the writer yields, with the command's exit-0 intact. Run `-count=3` under `-race`.
- Full `local` and `invoketest` suites green under `-race` — local is the suite's reference implementation, and the drain contracts (`cancel-during-drain-keeps-outcome` among them) exercise `finish` directly. `just check` green.