### PR TITLE
fix(local): Classification minors

### DIFF
--- a/local/classify_test.go
+++ b/local/classify_test.go
@@ -1,0 +1,117 @@
+package local_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ruffel/invoke"
+	"github.com/ruffel/invoke/local"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newLocalEnv builds a fresh environment and closes it with the test.
+func newLocalEnv(t *testing.T) *local.Environment {
+	t.Helper()
+
+	env, err := local.New()
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	return env
+}
+
+// TestUnenterableWorkdirIsClassified pins the second half of
+// ErrInvalidWorkdir's promise: a directory that "does not exist or
+// cannot be entered". A mode-000 directory exists and stats cleanly;
+// only an enterability check keeps it from surfacing as an exec failure
+// that blames the binary.
+func TestUnenterableWorkdirIsClassified(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() == 0 {
+		t.Skip("root enters everything; the classification is unobservable")
+	}
+
+	dir := filepath.Join(t.TempDir(), "sealed")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	require.NoError(t, os.Chmod(dir, 0))
+
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	env := newLocalEnv(t)
+
+	cmd := invoke.New("true")
+	cmd.Dir = dir
+
+	_, err := env.Start(t.Context(), cmd, invoke.IO{})
+	require.Error(t, err, "a sealed workdir cannot be used")
+
+	assert.ErrorIs(t, err, invoke.ErrInvalidWorkdir,
+		"a directory that cannot be entered is the workdir's fault")
+	assert.NotErrorIs(t, err, invoke.ErrNotFound,
+		"the binary exists; the workdir must not be blamed on it")
+}
+
+// TestUnexecutableBinaryIsNotFound pins Start and LookPath to the same
+// reading of the same input: a file without its execute bit did not
+// resolve to something runnable, whichever door it came through.
+func TestUnexecutableBinaryIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "not-runnable")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), 0o644))
+
+	env := newLocalEnv(t)
+
+	_, lookErr := env.LookPath(t.Context(), path)
+	assert.ErrorIs(t, lookErr, invoke.ErrNotFound, "LookPath's reading")
+
+	proc, startErr := env.Start(t.Context(), invoke.New(path), invoke.IO{})
+	if startErr == nil {
+		_ = proc.Close()
+
+		require.Fail(t, "a file without its execute bit cannot start")
+	}
+
+	assert.ErrorIs(t, startErr, invoke.ErrNotFound,
+		"Start must read the same input the way LookPath reads it")
+}
+
+// TestLookPathOfADirectoryIsNotFound pins the remaining shape of "did
+// not resolve to something runnable": a directory answers a path lookup
+// and is not an executable.
+func TestLookPathOfADirectoryIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	env := newLocalEnv(t)
+
+	_, err := env.LookPath(t.Context(), t.TempDir())
+	assert.ErrorIs(t, err, invoke.ErrNotFound,
+		"a directory is not something runnable")
+}
+
+// TestSignalAfterExitMatchesProcessDone pins the benign race every
+// Signal caller runs: the process may exit first, and the caller needs
+// a sentinel to match, not a string.
+func TestSignalAfterExitMatchesProcessDone(t *testing.T) {
+	t.Parallel()
+
+	env := newLocalEnv(t)
+
+	proc, err := env.Start(t.Context(), invoke.New("true"), invoke.IO{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = proc.Close() })
+
+	_, err = proc.Wait()
+	require.NoError(t, err)
+
+	err = proc.Signal(invoke.SIGTERM)
+	require.Error(t, err, "signaling a gone process must error")
+
+	assert.ErrorIs(t, err, os.ErrProcessDone,
+		"the benign outcome of the signal-versus-exit race needs a sentinel, not a string")
+}

--- a/local/local.go
+++ b/local/local.go
@@ -106,12 +106,14 @@ func (e *Environment) LookPath(ctx context.Context, name string) (string, error)
 	if err != nil {
 		// A bare name missing from PATH reports exec.ErrNotFound; a name
 		// with a separator is looked up as a path, so a missing or
-		// non-executable file reports the filesystem's own error instead.
-		// All of them mean the same thing to a caller: the name did not
-		// resolve to something runnable.
+		// non-executable file reports the filesystem's own error instead
+		// — and a directory reports its own errno again. All of them
+		// mean the same thing to a caller: the name did not resolve to
+		// something runnable.
 		if errors.Is(err, exec.ErrNotFound) ||
 			errors.Is(err, fs.ErrNotExist) ||
-			errors.Is(err, fs.ErrPermission) {
+			errors.Is(err, fs.ErrPermission) ||
+			namesDirectory(name) {
 			return "", fmt.Errorf("local: lookpath %q: %w", name, invoke.ErrNotFound)
 		}
 
@@ -161,11 +163,24 @@ func (e *Environment) untrack(p *process) {
 	delete(e.active, p)
 }
 
-// dirExists reports whether path names an existing directory; it backs the
-// workdir pre-check so a bad Dir classifies as ErrInvalidWorkdir instead of
-// surfacing as an ambiguous exec failure.
-func dirExists(path string) bool {
-	info, err := os.Stat(path)
+// namesDirectory reports whether name is a directory on disk, the one
+// unrunnable shape whose lookup error carries no portable sentinel.
+func namesDirectory(name string) bool {
+	info, err := os.Stat(name)
 
 	return err == nil && info.IsDir()
+}
+
+// usableDir reports whether path names a directory the command could
+// enter; it backs the workdir pre-check so a bad Dir classifies as
+// ErrInvalidWorkdir instead of surfacing as an exec failure that blames
+// the binary. Existing is half the promise: a directory that "cannot be
+// entered" — sealed by its mode — fails the same way.
+func usableDir(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+
+	return dirEnterable(path)
 }

--- a/local/options.go
+++ b/local/options.go
@@ -24,8 +24,10 @@ type Option func(*config)
 // is abandoned and Wait returns, which is why the default is short.
 //
 // A command that flushes something substantial when told to stop needs
-// longer than the default two seconds, or its last output is lost. A
-// caller that would rather never wait can set a shorter one.
+// longer than the default two seconds, or its last output is lost. Zero
+// and negative durations mean the default — the zero value is how an
+// unset configuration reads — so a caller that would rather barely wait
+// sets something tiny, not zero.
 func WithTerminationGrace(d time.Duration) Option {
 	return func(c *config) { c.terminationGrace = d }
 }

--- a/local/process.go
+++ b/local/process.go
@@ -67,7 +67,7 @@ func (e *Environment) Start(ctx context.Context, cmd invoke.Command, stdio invok
 		return nil, fmt.Errorf("local: start: %w", err)
 	}
 
-	if cmd.Dir != "" && !dirExists(cmd.Dir) {
+	if cmd.Dir != "" && !usableDir(cmd.Dir) {
 		return nil, fmt.Errorf("local: start: workdir %q: %w", cmd.Dir, invoke.ErrInvalidWorkdir)
 	}
 
@@ -156,7 +156,7 @@ func (p *process) Signal(sig invoke.Signal) error {
 	}
 
 	if p.waitReturned.Load() {
-		return errors.New("local: signal: process has exited")
+		return fmt.Errorf("local: signal: %w", os.ErrProcessDone)
 	}
 
 	sys, ok := sysSignal(sig)
@@ -166,7 +166,7 @@ func (p *process) Signal(sig invoke.Signal) error {
 
 	if err := signalGroup(p.execCmd.Process.Pid, sys); err != nil {
 		if errors.Is(err, os.ErrProcessDone) {
-			return errors.New("local: signal: process has exited")
+			return fmt.Errorf("local: signal: %w", os.ErrProcessDone)
 		}
 
 		return fmt.Errorf("local: signal %s: %w", sig, err)
@@ -360,7 +360,11 @@ func (p *process) exitOutcome(code int, sig invoke.Signal, signaled bool, durati
 }
 
 func classifyStartError(cmd invoke.Command, err error) error {
-	if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
+	// Permission joins the not-found family for the reason LookPath
+	// already folds it in: the name did not resolve to something
+	// runnable. The workdir pre-check has run by now, so a permission
+	// failure here is the binary's own.
+	if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrPermission) {
 		return fmt.Errorf("local: start %q: %w", cmd.Path, invoke.ErrNotFound)
 	}
 

--- a/local/process_unix.go
+++ b/local/process_unix.go
@@ -110,3 +110,12 @@ func signalName(sig syscall.Signal) invoke.Signal {
 		return invoke.Signal(strconv.Itoa(int(sig)))
 	}
 }
+
+// dirEnterable reports whether the directory's mode lets this process
+// enter it, which is what a working directory has to allow.
+func dirEnterable(path string) bool {
+	return syscall.Access(path, execPermission) == nil
+}
+
+// execPermission is access(2)'s X_OK: permission to traverse.
+const execPermission = 0x1

--- a/local/process_windows.go
+++ b/local/process_windows.go
@@ -32,3 +32,8 @@ func sysSignal(_ invoke.Signal) (syscall.Signal, bool) {
 func exitSignal(_ *os.ProcessState) (invoke.Signal, bool) {
 	return "", false
 }
+
+// dirEnterable reports whether the directory can be entered. Execution
+// semantics are out of scope on Windows, and its ACL model has no
+// access(2); an existing directory is taken at its word.
+func dirEnterable(_ string) bool { return true }

--- a/local/pty_clamp_internal_test.go
+++ b/local/pty_clamp_internal_test.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package local
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestClampDimPinsToTheMaximum pins the ceiling: a dimension beyond the
+// wire format's sixteen bits pins to the maximum instead of wrapping to
+// something unrelated — 70000 must not become 4464.
+func TestClampDimPinsToTheMaximum(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, uint16(80), clampDim(80), "an ordinary dimension passes through")
+	assert.Equal(t, uint16(math.MaxUint16), clampDim(math.MaxUint16), "the maximum itself passes through")
+	assert.Equal(t, uint16(math.MaxUint16), clampDim(70000), "beyond the maximum pins, never wraps")
+}

--- a/local/pty_unix.go
+++ b/local/pty_unix.go
@@ -5,6 +5,7 @@ package local
 import (
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"syscall"
@@ -46,8 +47,8 @@ func attachTerminal(cmd *exec.Cmd, requested *invoke.TTY) (*terminal, error) {
 	cols, rows := requested.Size()
 
 	if err := pty.Setsize(primary, &pty.Winsize{
-		Rows: uint16(rows), //nolint:gosec // Terminal dimensions are small positives.
-		Cols: uint16(cols), //nolint:gosec // Terminal dimensions are small positives.
+		Rows: clampDim(rows),
+		Cols: clampDim(cols),
 	}); err != nil {
 		_ = primary.Close()
 		_ = secondary.Close()
@@ -61,6 +62,18 @@ func attachTerminal(cmd *exec.Cmd, requested *invoke.TTY) (*terminal, error) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true}
 
 	return &terminal{primary: primary, secondary: secondary, copied: make(chan struct{})}, nil
+}
+
+// clampDim fits a terminal dimension into the wire format's sixteen
+// bits. Size() has already floored non-positive values, so only the
+// ceiling needs enforcing: a dimension beyond it pins to the maximum
+// rather than silently wrapping to something unrelated.
+func clampDim(v int) uint16 {
+	if v > math.MaxUint16 {
+		return math.MaxUint16
+	}
+
+	return uint16(v) //nolint:gosec // Bounded above, floored by Size().
 }
 
 // start begins moving bytes once the command is running, and releases the


### PR DESCRIPTION
## What

Five repairs, each aligning an answer with a promise already made:

- **A sealed workdir is the workdir's fault.** `ErrInvalidWorkdir`'s doc promises "does not exist or cannot be entered"; the pre-check only statted, so a mode-000 directory passed it and surfaced as `fork/exec …: permission denied` blaming the binary. The pre-check now tests enterability (`access(2)` X_OK on unix; the Windows stub takes an existing directory at its word — execution there is out of scope).
- **Start and LookPath agree about non-executable files.** A file without its execute bit was `ErrNotFound` from `LookPath` (which folds `fs.ErrPermission` in deliberately) and an unclassified error from `Start`. `classifyStartError` now folds permission in too — safe to attribute to the binary, since the workdir pre-check has already run.
- **`LookPath` of a directory is `ErrNotFound`.** Its errno carries no portable sentinel, so the shape is recognized by a stat: a directory did not resolve to something runnable.
- **`Signal` after exit wraps `os.ErrProcessDone`.** The benign outcome of the signal-versus-exit race — the common case for Signal — is now a sentinel callers can `errors.Is`, not a string.
- **TTY dimensions clamp instead of wrapping.** 70000 columns pinned to 65535, not truncated to 4464; the gosec justification is now enforced by construction and pinned by a unit test.

Plus the `WithTerminationGrace` doc now tells the truth about zero: it means the default two seconds (the zero value is how an unset configuration reads), not "never wait".

## Verification

- Four behavior tests written first, all red (sealed workdir, non-executable via Start, directory via LookPath, signal-after-exit sentinel), plus the clamp unit test; all green after, under `-race`.
- The sealed-workdir test skips under root, where everything is enterable and the classification is unobservable.
- `just check` green, including the Windows cross-build that the new per-OS `dirEnterable` split has to satisfy.