### PR TITLE
docs(readme): Restructure on the conventions strong libraries share

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,42 +6,121 @@
 Run commands and transfer files on the local machine, remote SSH hosts, and
 containers through one provider-agnostic Go interface.
 
+## Features
+
+- **One interface, four targets.** `local`, `ssh`, `docker`, and an
+  in-memory `fake` all satisfy the same `Environment` contract; the
+  constructor is the only line that changes.
+- **Contract-verified behavior.** An executable suite enforces the
+  semantics against every provider — cancellation really terminates,
+  signals really deliver, transfers land whole or not at all — including
+  against a real OpenSSH server and a real container on every change. The
+  suite tests itself: a contract that cannot be made to fail does not
+  merge.
+- **Retry-safe by construction.** The error taxonomy separates "ran and
+  failed" from "could not run" from "the caller stopped it", and only
+  transport failures — the one family that says the command did not run —
+  are ever retried. A retry can never run a side-effectful command twice.
+- **A test double that cannot drift.** The fake passes the same contract
+  suite as the real providers, so tests written against it cannot come to
+  rely on behavior no real target has.
+
+## Installation
+
 ```sh
 go get github.com/ruffel/invoke
 go get github.com/ruffel/invoke/docker   # only if you need containers
 ```
 
-The API reference and runnable examples are on
-[pkg.go.dev](https://pkg.go.dev/github.com/ruffel/invoke); each release is
-documented on [GitHub Releases](https://github.com/ruffel/invoke/releases).
+Docker is a separate module, so its SDK dependency tree stays out of the
+graph of anyone who does not use it.
+
+## Quick start
 
 ```go
-env, err := local.New()          // or ssh.New(ctx, host, ...), docker.New(ctx, container, ...)
-if err != nil {
-    return err
-}
-defer env.Close()
+package main
 
-_, stdout, _, err := invoke.NewExecutor(env).Output(ctx, invoke.New("uname", "-s"))
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/ruffel/invoke"
+	"github.com/ruffel/invoke/local"
+)
+
+func main() {
+	env, err := local.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer env.Close()
+
+	_, out, _, err := invoke.NewExecutor(env).Output(
+		context.Background(), invoke.New("uname", "-s"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Print(string(out))
+}
 ```
 
-Constructing the target is the only line that changes between them.
+An `Environment` is a connection to a target; an `Executor` wraps one and
+adds the policy most callers want — output capture, retries, sudo. A
+`Command` is a plain value with no streams and no state, so the same one
+runs repeatedly or against several targets; where output goes belongs to
+the invocation, not the command. Transfers ride the same environment:
+`exec.Upload(ctx, "./dist", "/srv/app")` copies a file or a whole tree.
 
-## Design principles
+To run the same command elsewhere, construct a different target. A remote
+host authenticates with a key file, the agent (`ssh.WithAgent`), or a
+password, and verifies the host key against the file you name — there is
+no trust-on-first-use:
 
-- **One interface per target.** Every provider implements the same
-  `Environment` contract; swapping targets does not change semantics.
-- **Contracts over documentation.** Provider behavior is enforced by an
-  executable suite (`invoketest`), including the failure modes:
-  cancellation really terminates processes, signals really deliver,
-  transfers really are atomic. The suite also tests itself — every
-  contract must be provably capable of failing, or it does not merge.
-- **Honest errors.** The taxonomy always distinguishes "the command ran and
-  failed" from "the command could not run" from "the caller stopped it" —
-  and only transport failures are ever retried.
-- **POSIX targets this cycle.** Linux and macOS hosts, Linux containers.
-  Everything compiles on Windows, but execution semantics are out of scope
-  for now.
+```go
+env, err := ssh.New(ctx, "build-3.example.net",
+	ssh.WithUser("deploy"),
+	ssh.WithPrivateKey(home+"/.ssh/id_ed25519"),
+	ssh.WithKnownHosts(home+"/.ssh/known_hosts"),
+)
+```
+
+A container is named by name or ID, and the daemon is found the way the
+`docker` command finds it — `WithHost`, a named context, `DOCKER_HOST`,
+then the current context:
+
+```go
+env, err := docker.New(ctx, "build-cache")
+```
+
+Runnable examples for every concept — retries, capabilities, the fake,
+transfers — are on
+[pkg.go.dev](https://pkg.go.dev/github.com/ruffel/invoke#pkg-examples).
+
+## Handling failure
+
+Every failure answers one question first: did the command run? Branch on
+the kind, never the message:
+
+```go
+_, err := exec.Run(ctx, invoke.Shell("systemctl restart app"), invoke.IO{})
+
+var exitErr *invoke.ExitError
+
+switch {
+case err == nil: // ran and exited zero
+case errors.As(err, &exitErr): // ran and failed; the exit status is trustworthy
+	log.Printf("restart failed with exit %d", exitErr.Code)
+case errors.Is(err, invoke.ErrNotFound): // could not start: no such executable
+default: // everything else, including transport — the only family retries re-run
+	log.Print(err)
+}
+```
+
+`invoke.WithRetry(3, invoke.ExponentialBackoff(time.Second))` re-runs
+transport failures and nothing else; the reasoning is under
+[Caveats](#caveats).
 
 ## Providers
 
@@ -52,10 +131,7 @@ Constructing the target is the only line that changes between them.
 | SSH | `ssh` | an in-process server, and a real OpenSSH server |
 | Docker | `docker` (submodule) | a real container |
 
-Docker is a separate module, so its SDK dependency tree stays out of the
-graph of anyone who does not use it.
-
-## Capabilities
+### Capabilities
 
 Targets differ in what they can do and say so through `Capabilities()`.
 The rule is symmetric and the suite enforces both halves: a declared
@@ -82,7 +158,46 @@ children depends on the target: local runs commands in their own process
 group and signals the group, as a terminal does; ssh and docker address
 the single process.
 
-## Things worth knowing
+## Testing your own code
+
+`fake` is a working target that keeps its filesystem in memory. It is not a
+mock: it passes the same contract suite the real providers do, so a test
+written against it cannot come to rely on behavior no real target has.
+
+Its shell interprets a subset — sequencing with `;` and `&&`, quoting,
+`$NAME` and `${NAME}`, `$(...)` substitution, redirection to `/dev/null`
+and between the output streams — and refuses what it cannot run, naming
+it, rather than running it wrongly. A pipeline, a `||` list, a glob, a
+comment: each fails with `ErrNotSupported` instead of quietly meaning
+something else, and the builtins answer truthfully or refuse loudly.
+Script anything beyond the subset with `Handle`, or run it against a real
+target.
+
+```go
+env := fake.New()
+env.Handle("systemctl", func(_ context.Context, cmd invoke.Command, s *fake.Session) int {
+    return 0
+})
+
+// ... exercise your code against env ...
+
+for _, call := range env.Calls() {
+    // assert on what your code asked to run
+}
+```
+
+Any `Environment` implementation outside this repository can be held to
+the same contracts:
+
+```go
+func TestMyProvider(t *testing.T) {
+    invoketest.Verify(t, func(t invoketest.T) invoke.Environment {
+        return myprovider.New()
+    })
+}
+```
+
+## Caveats
 
 Each of these is a real constraint of the target rather than a limitation
 of the API, and each is covered by a test.
@@ -106,58 +221,21 @@ them.
 staging transfers. Without one, both report `ErrNotSupported` rather than
 misbehaving.
 
-**Docker finds its daemon the way the `docker` command does**: an endpoint
-passed to `WithHost`, then a context named with `WithContext`, then
-`DOCKER_HOST`, then the current context. A context reached over TLS is
-reported as unsupported rather than connected to without its
-certificates.
-
 **A command can outlive its own exit.** Something it left running may still
 hold its output open, so `Wait` gives up after a grace period rather than
 blocking forever. `local.WithTerminationGrace` sets how long that is; the
 default is two seconds, which is short enough to lose the last output of a
 command that flushes something substantial on the way out.
 
-## Testing your own code
+## Stability
 
-`fake` is a working target that keeps its filesystem in memory. It is not a
-mock: it passes the same contract suite the real providers do, so a test
-written against it cannot come to rely on behavior no real target has.
+Pre-1.0: breaking changes land as minor releases and every one is called
+out in the [release notes](https://github.com/ruffel/invoke/releases).
+POSIX targets this cycle — Linux and macOS hosts, Linux containers.
+Everything compiles on Windows, but execution semantics are out of scope
+for now. Go 1.25 or newer.
 
-Its shell interprets a subset — sequencing, quoting, `$NAME`, `$(...)`,
-redirection to `/dev/null` and between the output streams — and refuses
-what it cannot run, naming it, rather than running it wrongly. A pipeline
-or a `||` list fails with `ErrNotSupported` instead of quietly becoming
-arguments to the first command. Script anything beyond the subset with
-`Handle`, or run it against a real target.
-
-```go
-env := fake.New()
-env.Handle("systemctl", func(_ context.Context, cmd invoke.Command, s *fake.Session) int {
-    return 0
-})
-
-// ... exercise your code against env ...
-
-for _, call := range env.Calls() {
-    // assert on what your code asked to run
-}
-```
-
-## Verifying a provider of your own
-
-`invoketest` is the suite itself, and any `Environment` implementation can
-be run against it:
-
-```go
-func TestMyProvider(t *testing.T) {
-    invoketest.Verify(t, func(t invoketest.T) invoke.Environment {
-        return myprovider.New()
-    })
-}
-```
-
-## Development
+## Contributing
 
 ```
 just check              # format, lint, tidy, cross-build, race tests
@@ -165,10 +243,8 @@ just test-integration   # everything needing a container runtime
 ```
 
 The integration lanes run the suite against a real OpenSSH server and a
-real container, and compare the providers against each other. They need a
-container runtime, so they are not part of `just check`.
-
-Conventions for commits, pull requests, and behavioral changes are in
+real container, and compare the providers against each other. Conventions
+for commits, pull requests, and behavioral changes are in
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License


### PR DESCRIPTION
## What

Reconstructed on the scaffold widely admired Go libraries (testify, zap, gin, cobra) converge on, rather than my earlier tutorial-in-a-README shape:

- **Features** directly under the pitch — the selling points as user benefits (one interface / contract-verified / retry-safe / a fake that cannot drift), absorbing what "Design principles" said 110 lines down.
- **Installation**, then **one** compact, complete quickstart program — with prose carrying the orientation, and the ssh/docker constructors following under it. The SSH example shows real authentication (key file, known_hosts) with the fail-closed posture stated beside it; the docker example carries the daemon-discovery order.
- **Handling failure** — the `errors.As`/`errors.Is` branch every consumer writes on day one, compressed, with retry semantics one line later.
- **Stability** — the section adopters scan for and couldn't find: pre-1.0 breaking-changes-as-minors with release-notes callouts, the POSIX platform cycle, Go version.
- Conventional, scannable headers throughout: `Caveats` (was "Things worth knowing", content intact), `Contributing` (was "Development"), Capabilities folded under Providers, the provider-author `Verify` block folded under Testing your own code, and an explicit link to the runnable pkg.go.dev examples where a reader wants more.

The repo's voice stays in the prose; the scaffold is what became conventional. The fake's subset paragraph is also brought up to date with the shell as it now is.

## Verification

Every fenced Go block compiles verbatim — the quickstart directly, the ssh/docker/taxonomy/fake fragments in a harness — against both modules. `just check` green.