### PR TITLE
test(ssh): Answer exec before the command can close the channel

### DIFF
--- a/ssh/testserver_test.go
+++ b/ssh/testserver_test.go
@@ -418,9 +418,16 @@ func (s *testServer) handleSession(channel ssh.Channel, requests <-chan *ssh.Req
 				line = "echo " + s.unameOutput
 			}
 
-			go runExec(channel, state, line)
-
+			// The reply must go out before the command starts. A command can
+			// finish and close the channel in single-digit milliseconds, and a
+			// closed channel silently drops the reply — the client's pending
+			// exec request then fails with EOF, reporting a transport failure
+			// on a connection that never failed. A real sshd answers the
+			// request before it runs the command, so the ordering is also
+			// what this server exists to imitate.
 			reply(req, true)
+
+			go runExec(channel, state, line)
 		case "pty-req":
 			if s.refusePTY {
 				reply(req, false)


### PR DESCRIPTION
## The failure

`TestSeveredConnectionDuringCommandIsTerminal` intermittently fails in the openssh CI lane at transport_test.go:39 with

    ssh: start: transport failure during run: EOF

on a mid-loop attempt (run 30044327179 hit it on attempt 4, on a docs-only PR). The failing call is Start's pre-flight exec — before that attempt's `srv.sever()` — so a brand-new connection appeared to die that nothing in the test had touched.

## Root cause

The in-process server handled exec by spawning the command's goroutine first and answering the request second:

```go
go runExec(channel, state, line)

reply(req, true)
```

The pre-flight check runs `sh -c 'command -v …'`, which finishes in single-digit milliseconds. If the session goroutine loses the processor between those two lines for longer than that — the starvation a loaded two-core runner under `-race` supplies — `runExec` sends the exit status and closes the channel before the reply is written. x/crypto then drops the late reply (`channel.writePacket` returns `io.EOF` once `sentClose` is set, and `reply` ignores it), and the client blocked in `SendRequest("exec", wantReply=true)` sees its message channel close and returns `io.EOF`. `classifyRaw` correctly reports that as a TransportError — on a connection that never failed.

Injecting a 20ms delay between the spawn and the reply reproduces the CI failure deterministically: same line, same message, first attempt. Ruled out along the way: conn tracking and sever are genuinely per-server-instance; an accept-loop death cannot affect an already-handshaked connection (and would surface as a handshake timeout, not a run-time EOF); the client's handshake deadline is cleared before the first session; keepalive is 30s against a test that lives about two seconds.

## The fix

Answer the request, then start the command. Both writes leave the same goroutine in order, so no schedule can put the close ahead of the reply — and a real sshd also answers exec before running the command, so the ordering is what this server exists to imitate. The subsystem path already replied first; exec was the only inversion.

With the reply sent first, the injected-delay reproduction passes. The test itself is unchanged and stays strict: a Start-time transport failure against a healthy in-process server is a real bug again, not something to retry around.

## Verification

- `just check` green
- `just test-openssh` (tagged lane, real sshd container) green
- Stress on the pre-fix code (GOMAXPROCS=2, all cores hogged, `-race`): ten full-package runs plus ~1000 focused iterations of the failing test stayed green on a workstation — the natural window needs a colder scheduler than a local machine provides, consistent with the failure appearing only on shared runners and never in 40 isolated local runs.
