### PR TITLE
ci: Repair release drafter's labelling and retire its deprecated configuration

### DIFF
--- a/.github/pr-label.sh
+++ b/.github/pr-label.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Maps a Conventional Commit pull request title to the labels release
+# drafter reads for categories and version resolution, printing one per
+# line. No output means no label applies.
+#
+# This lives outside the workflow so it can be exercised directly:
+#
+#     .github/pr-label.sh 'fix(fake)!: refuse a script the shell cannot run'
+#
+# Labelling was release drafter's own job until its v7 release, which
+# forces dry-run mode whenever the ref is a pull request's ephemeral
+# merge commit — every label write was silently discarded, and with no
+# labels every draft resolved to a patch however much had changed. Doing
+# it here is one fewer thing that can fail quietly, and one fewer
+# third-party action holding a write token on pull request events.
+set -euo pipefail
+
+title=${1?usage: pr-label.sh <pull request title>}
+
+# The breaking marker raises the minor, and pre-1.0 that is as far as it
+# goes. Any type may carry it: "fix(fake)!:" as readily as "feat!:".
+if [[ $title =~ ^[[:alnum:]]+(\(.+\))?!: ]]; then
+	echo breaking
+fi
+
+# One label per Conventional Commit type, matching however the title
+# spells the rest: an optional scope, an optional breaking marker.
+for rule in \
+	'feat:feature' \
+	'fix:fix' \
+	'test:test' \
+	'docs:documentation' \
+	'build|ci|refactor|chore|style|perf:chore'; do
+	types=${rule%:*}
+	label=${rule##*:}
+
+	if [[ $title =~ ^($types)(\(.+\))?!?: ]]; then
+		echo "$label"
+	fi
+done

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,66 +4,77 @@
 #
 # The draft is a starting point rather than the finished notes. It groups by
 # the kind of change, and a release worth reading usually groups by theme
-# and says why each change mattered; v0.4.0's notes did, and no generator
-# would have produced them. Edit before publishing.
+# and says why each change mattered; v0.4.0's and v0.5.0's notes did, and no
+# generator would have produced them. Edit before publishing.
+#
+# Every rule below lives on a category, which is the one schema v7 is not
+# deprecating: a category says what it is (type), what it collects (when),
+# and what it does to the version (semver-increment). The older spellings —
+# categories[*].labels, exclude-labels, version-resolver — still work but
+# warn on every run, and they are documented as going away. Migrating on a
+# warning rather than on a removal is the difference between doing this
+# deliberately and doing it under a broken release.
 
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 
 categories:
+  # Dropped before anything else looks at it.
+  - type: pre-exclude
+    when:
+      labels: ['skip-changelog']
+
+  # Pre-1.0, a breaking change raises the minor rather than the major.
+  # semver-increment is deliberately absent everywhere it would say
+  # "patch", which is its default; naming it only where a category lifts
+  # the version keeps the two that do visible. No category says "major":
+  # v1.0.0 is a decision to take deliberately, not one to arrive at by
+  # labelling.
   - title: 'Breaking changes'
-    labels: ['breaking']
+    when:
+      labels: ['breaking']
+    semver-increment: minor
   - title: 'Security'
-    labels: ['security']
+    when:
+      labels: ['security']
   - title: 'Features'
-    labels: ['feature']
+    when:
+      labels: ['feature']
+    semver-increment: minor
   - title: 'Fixes'
-    labels: ['fix']
+    when:
+      labels: ['fix']
   - title: 'Contracts and tests'
-    labels: ['test']
+    when:
+      labels: ['test']
   - title: 'Documentation'
-    labels: ['documentation']
+    when:
+      labels: ['documentation']
   - title: 'Build and CI'
-    labels: ['chore']
+    when:
+      labels: ['chore']
 
 change-template: '- $TITLE (#$NUMBER)'
 
 # A title carrying markdown of its own would otherwise render as markdown.
 change-title-escapes: '\<*_&'
 
-# Pre-1.0, a breaking change raises the minor rather than the major. No
-# major bucket is listed on purpose: leaving one would let an ordinary
-# release resolve to v1.0.0, which is a decision to take deliberately and
-# not one to arrive at by labelling.
-version-resolver:
-  minor:
-    labels:
-      - 'breaking'
-      - 'feature'
-  patch:
-    labels:
-      - 'security'
-      - 'fix'
-      - 'test'
-      - 'documentation'
-      - 'chore'
-  default: patch
-
-# The labels above are applied from the pull request title by
-# .github/pr-label.sh, which the workflow runs on every pull request.
-# They are not applied from here: release drafter's own autolabeler
-# stopped writing labels at v7, which forces dry-run mode whenever the
-# ref is a pull request's ephemeral merge commit. The block that used to
-# live here is gone rather than kept as decoration — configuration that
-# silently does nothing is how this broke in the first place.
+# A pull request matching no category at all resolves the version by the
+# schema's own default, which is patch — the behaviour the version-resolver
+# block used to spell out.
+#
+# The labels themselves are applied from the pull request title by
+# .github/pr-label.sh, which the workflow runs on every pull request. They
+# are not applied from here: release drafter's own autolabeler stopped
+# writing labels at v7, which forces dry-run mode whenever the ref is a
+# pull request's ephemeral merge commit. The block that used to live here
+# is gone rather than kept as decoration — configuration that silently
+# does nothing is how this broke in the first place.
 #
 # A breaking change carries the Conventional Commits "!" marker, as in
 # "fix(fake)!: ...". That marker is the only thing that raises the minor:
 # a breaking change titled without it drafts as a patch. The convention
 # is stated in CONTRIBUTING.md.
-
-exclude-labels:
-  - 'skip-changelog'
 
 template: |
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -49,29 +49,18 @@ version-resolver:
       - 'chore'
   default: patch
 
-# Labels are read from the pull request title, which this repository writes
-# as a Conventional Commit. Labelling was the step the previous setup
-# omitted, and without it every release resolved to a patch however much had
-# changed.
+# The labels above are applied from the pull request title by
+# .github/pr-label.sh, which the workflow runs on every pull request.
+# They are not applied from here: release drafter's own autolabeler
+# stopped writing labels at v7, which forces dry-run mode whenever the
+# ref is a pull request's ephemeral merge commit. The block that used to
+# live here is gone rather than kept as decoration — configuration that
+# silently does nothing is how this broke in the first place.
 #
 # A breaking change carries the Conventional Commits "!" marker, as in
-# "fix(fake)!: ...". That is what the rule below matches, and it is the only
-# thing that raises the minor: a breaking change titled without it drafts as
-# a patch, which is the previous failure in a new form. The convention is
-# stated in the README, under Development.
-autolabeler:
-  - label: 'breaking'
-    title: '/^\w+(\(.+\))?!:/'
-  - label: 'feature'
-    title: '/^feat(\(.+\))?!?:/'
-  - label: 'fix'
-    title: '/^fix(\(.+\))?!?:/'
-  - label: 'test'
-    title: '/^test(\(.+\))?!?:/'
-  - label: 'documentation'
-    title: '/^docs(\(.+\))?!?:/'
-  - label: 'chore'
-    title: '/^(build|ci|refactor|chore|style|perf)(\(.+\))?!?:/'
+# "fix(fake)!: ...". That marker is the only thing that raises the minor:
+# a breaking change titled without it drafts as a patch. The convention
+# is stated in CONTRIBUTING.md.
 
 exclude-labels:
   - 'skip-changelog'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,26 +1,27 @@
-# Keeps a draft release current as pull requests merge. The configuration
-# lives in .github/release-drafter.yml.
+# Keeps a draft release current as pull requests merge, so cutting a
+# release is publishing something already written rather than recalling
+# what changed.
 #
-# That configuration is read from the default branch, always — never from
-# the branch being built. So this fails with "Configuration file ... is not
-# found" on the pull request that introduces it, and on any later one that
-# only edits it: what runs is whatever main already holds. A change to the
-# configuration is therefore proved by the run after it merges, not by the
-# run on its own pull request.
+# The draft reads labels — for its categories and for whether a release is
+# a minor or a patch — and those labels come from the pull request title,
+# applied by the label job below rather than by release drafter itself.
+# Its own autolabeler stopped writing them at v7, which forces dry-run
+# mode whenever the ref is a pull request's ephemeral merge commit; every
+# write was discarded in silence, and with no labels every draft resolved
+# to a patch however much had changed.
+#
+# The drafting configuration lives in .github/release-drafter.yml, and is
+# read from the default branch, always — never from the branch being
+# built. So a change to that file is proved by the run after it merges,
+# not by the run on its own pull request. The label job is not subject to
+# this: it runs the script from the branch under test.
 name: Release drafter
 
-# Drafting runs on main rather than on a tag. This repository tags two
-# modules together — vX.Y.Z and docker/vX.Y.Z — and drafting per tag would
-# raise a second, duplicate draft for the submodule. Keeping the draft
-# current on main means the notes already exist when the tag is pushed.
 on:
   push:
     branches: [main]
-  # Labels a pull request as it arrives or is retitled, which is what both
-  # the categories and the version resolution read. A pull request from a
-  # fork carries a read-only token, so its labels have to be applied by
-  # hand; pull_request_target would fix that by running with write access
-  # against code from the fork, which is not a trade worth making.
+  # Labels a pull request as it arrives or is retitled, which is what the
+  # draft reads once it merges.
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
@@ -32,13 +33,73 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  label:
+    name: Label the pull request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write # Apply the labels.
+      issues: write # Create one the repository does not have yet.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Apply the labels its title implies
+        # A pull request from a fork carries a read-only token, so its
+        # labels have to be applied by hand. pull_request_target would
+        # fix that by running with write access against code from the
+        # fork, which is not a trade worth making.
+        if: github.event.pull_request.head.repo.fork == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A title is whatever its author typed. Interpolating one into
+          # the script below would run it; an environment variable is
+          # read as data.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          labels=$(.github/pr-label.sh "$PR_TITLE")
+
+          if [ -z "$labels" ]; then
+            echo "\"$PR_TITLE\" names no Conventional Commit type; nothing to label" >&2
+            exit 0
+          fi
+
+          # A label the repository has never used yet is created rather
+          # than reported: the set is decided by the drafting categories,
+          # and a release should not be miscategorized over a colour.
+          while IFS= read -r label; do
+            case "$label" in
+              breaking) colour=b60205 ;;
+              security) colour=d93f0b ;;
+              feature) colour=0e8a16 ;;
+              fix) colour=1d76db ;;
+              test) colour=5319e7 ;;
+              documentation) colour=0075ca ;;
+              *) colour=ededed ;;
+            esac
+
+            if ! gh label list --json name --jq '.[].name' | grep -qxF "$label"; then
+              gh label create "$label" --color "$colour" \
+                --description "Groups this change in the release notes."
+            fi
+          done <<<"$labels"
+
+          echo "labelling #$PR_NUMBER: $(echo "$labels" | paste -sd, -)"
+          gh pr edit "$PR_NUMBER" --add-label "$(echo "$labels" | paste -sd, -)"
+
+  # Drafting runs on main rather than on a tag. This repository tags two
+  # modules together — vX.Y.Z and docker/vX.Y.Z — and drafting per tag
+  # would raise a second, duplicate draft for the submodule. Keeping the
+  # draft current on main means the notes already exist when the tag is
+  # pushed.
   draft:
     name: Update the draft release
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: write # Write the draft release.
-      pull-requests: write # Apply labels.
     steps:
       - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0
         env:


### PR DESCRIPTION
Two changes to the same subsystem: release drafter's labels never reached it, and the configuration it reads is written in a spelling it is retiring.

## The labels were never applied

Release drafter reads labels — for its categories and for whether a release is a minor or a patch — and **no pull request in this repository has ever had one**. Its autolabeler stopped writing them at v7 (which dependabot bumped us to in #23): v7 forces dry-run mode whenever the ref is a pull request's ephemeral merge commit, and the run log says so plainly:

```
refs/pull/47/merge points to an ephemeral pull request merge commit;
forcing dry-run mode and disabling publish
```

With no labels, version resolution fell to the patch default — the draft for v0.5.0, which carried three breaking changes, offered `v0.4.1`. That is exactly the failure #21 introduced labelling to prevent, returned in a new form.

- **Labelling moves into the workflow**, driven by `.github/pr-label.sh` — a script rather than buried YAML, so it can be run and tested directly.
- **Missing labels are created, not reported.** Only `documentation` and `chore` of the six actually existed, so `gh pr edit --add-label breaking` would have failed outright.
- **The title is passed as an environment variable, never interpolated** into the shell. A title is whatever its author typed; interpolating one would execute it.
- **Release drafter now runs only on `push`**, where its ref is a real commit and it has work it can do. That also stops a third-party action holding a `contents: write` token on pull request events.
- The dead `autolabeler:` block is deleted, not left as decoration.

Fork pull requests still carry a read-only token and are still labelled by hand; `pull_request_target` would fix that by running with write access against code from a fork, which remains a trade not worth making.

## The configuration was written in a retired spelling

v7 warns on every run that `categories[*].labels`, `exclude-labels` and `version-resolver` are deprecated and will be removed. Nothing is broken today — but a major bump is precisely how the labelling above came to fail in silence, and waiting for the removal means discovering it mid-release.

Every rule now lives on a category, the one schema v7 is not retiring: a category says what it is (`type`), what it collects (`when`), and what it does to the version (`semver-increment`). `exclude-labels` becomes a `pre-exclude` category; `version-resolver`'s buckets become `semver-increment` on the categories that already group those labels. `semver-increment` is named only on the two categories that lift the version, since `patch` is its default — which keeps the two that matter visible. No category says `major`: v1.0.0 stays a deliberate decision rather than one arrived at by labelling.

## Verification

This is configuration read from the **default branch, always**, so the drafting half cannot be proved by its own pull request. Rather than merge and hope:

- **Schema**: validated against release drafter **v7.6.0's own `schema.json`** — the exact version pinned here — and no deprecated field remains in the file.
- **Equivalence**: for each of the seven labels, plus `skip-changelog` and an unlabelled pull request, the category, the version bump, and whether it is excluded are **identical** before and after. All nine cases agree.
- **Unlabelled behaviour**: deleting `version-resolver` is safe because the schema's own default for it is `patch`, which is what the block spelled out.

The labelling half *is* provable here, and is proved:

- Every title in `v0.4.0..v0.5.0` replayed through the script: the three `fix(fake)!` commits earn `breaking,fix` (so the draft would have resolved to a **minor**), every other commit earns exactly one type label, a non-conventional title earns none.
- Edge cases: `feat!:` with no scope, `refactor(ssh)!:`, and a title with parentheses later in the sentence.
- The workflow step extracted and executed locally against a stub `gh` reporting this repository's real label set: it creates only the two missing labels, with the right colours, and exits cleanly on a non-conventional title.
- **In production**: this pull request self-labelled `chore`, with the job's log reading `labelling #48: chore` — so the label came from the script, not by coincidence. `Update the draft release` correctly skipped on the pull request event.
- `just check` green.
