### PR TITLE
feat(executor): Attach a stderr tail when the caller discards stderr

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -58,8 +58,8 @@ type ExitError struct {
 	Signal Signal
 
 	// Stderr optionally holds a tail of the process's standard error,
-	// attached by capture helpers for diagnostics. Providers leave it
-	// empty when output went to the caller's own writers.
+	// attached by the [Executor] for diagnostics whenever the caller did
+	// not claim the stream. Providers leave it empty.
 	Stderr []byte
 }
 

--- a/executor.go
+++ b/executor.go
@@ -17,14 +17,20 @@ const (
 	lineScannerStart = 64 * 1024
 	lineScannerMax   = 1024 * 1024
 
-	// maxStderrTail bounds the stderr snippet attached to an ExitError by
-	// Output, for diagnostics without unbounded memory.
+	// maxStderrTail bounds the stderr tail attached to an ExitError, for
+	// diagnostics without unbounded memory.
 	maxStderrTail = 8 * 1024
 )
 
 // Executor adds invocation policy — retry, sudo, and output capture — on
 // top of an [Environment]. The Environment is the mechanism (start a
 // process, move a file); the Executor is the policy layer over it.
+//
+// Failure diagnostics survive by default: an [ExitError] returned by any
+// of its methods carries a bounded tail of the command's standard error
+// unless the caller claimed the stream — by wiring a Stderr writer of
+// their own, by requesting a TTY (which merges standard error into
+// standard output), or by passing [io.Discard] to discard deliberately.
 //
 // Only the operations that carry policy are exposed here (Run, Output,
 // Lines, Upload, Download). For LookPath, OS, Capabilities, or Close, use
@@ -48,6 +54,11 @@ func NewExecutor(env Environment, opts ...Option) *Executor {
 
 // Run starts cmd with the given IO, waits for it, and returns the outcome,
 // applying the configured retry and sudo policy.
+//
+// When stdio carries no Stderr writer and no TTY, Run retains a bounded
+// tail of standard error and attaches it to an [ExitError], so a failed
+// fire-and-forget command still reports why. Pass [io.Discard] as the
+// Stderr to discard standard error unconditionally.
 //
 // When retries are configured and stdio carries a non-nil Stdin, a
 // [WithFreshIO] provider is required: a consumed reader cannot be replayed
@@ -73,7 +84,18 @@ func (e *Executor) Run(ctx context.Context, cmd Command, stdio IO, opts ...Optio
 			attemptIO = cfg.freshIO(attempt)
 		}
 
-		return e.once(ctx, cmd, attemptIO)
+		// A fresh tail per attempt: a retried command's ExitError must
+		// carry the failing attempt's stderr, not its predecessors'.
+		var tw *tailWriter
+		if attemptIO.Stderr == nil && attemptIO.TTY == nil {
+			tw = &tailWriter{max: maxStderrTail}
+			attemptIO.Stderr = tw
+		}
+
+		res, err := e.once(ctx, cmd, attemptIO)
+		attachStderrTail(err, tw)
+
+		return res, err
 	})
 }
 
@@ -104,7 +126,8 @@ func (e *Executor) Output(ctx context.Context, cmd Command, opts ...Option) (Res
 }
 
 // Lines runs cmd and calls onLine for each line of its standard output.
-// Stderr is discarded. It applies the same retry and sudo policy as Run;
+// Stderr goes nowhere, though an [ExitError] still carries a bounded tail
+// of it. Lines applies the same retry and sudo policy as Run;
 // note that a failed-then-retried attempt may have already delivered some
 // lines before failing.
 //
@@ -232,7 +255,9 @@ func (e *Executor) streamOnce(ctx context.Context, cmd Command, onLine func(stri
 		scanErr <- scanner.Err()
 	}()
 
-	proc, err := e.env.Start(ctx, cmd, IO{Stdout: pw})
+	tw := &tailWriter{max: maxStderrTail}
+
+	proc, err := e.env.Start(ctx, cmd, IO{Stdout: pw, Stderr: tw})
 	if err != nil {
 		_ = pw.Close()
 		_ = pr.Close()
@@ -253,6 +278,8 @@ func (e *Executor) streamOnce(ctx context.Context, cmd Command, onLine func(stri
 
 	switch {
 	case waitErr != nil:
+		attachStderrTail(waitErr, tw)
+
 		return res, waitErr
 	case sErr != nil:
 		return res, fmt.Errorf("invoke: streaming output: %w", sErr)
@@ -356,6 +383,47 @@ func applySudo(cfg execConfig, cmd Command) Command {
 	args = append(args, cmd.Args...)
 
 	return Command{Path: "sudo", Args: args, Env: cmd.Env, Dir: cmd.Dir}
+}
+
+// attachStderrTail copies the retained stderr tail onto an [ExitError]
+// that does not already carry one. Any other error, an empty tail, or a
+// nil writer (the caller claimed the stream) leaves err untouched.
+func attachStderrTail(err error, tw *tailWriter) {
+	if tw == nil || len(tw.buf) == 0 {
+		return
+	}
+
+	var exitErr *ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) == 0 {
+		exitErr.Stderr = tw.buf
+	}
+}
+
+// tailWriter retains the last max bytes written through it, so a failing
+// command's stderr can travel on its [ExitError] without unbounded
+// memory. An invocation's stderr has a single writer, so it does not
+// synchronize.
+type tailWriter struct {
+	max int
+	buf []byte
+}
+
+// Write implements io.Writer; it never fails.
+func (w *tailWriter) Write(p []byte) (int, error) {
+	if len(p) >= w.max {
+		w.buf = append(w.buf[:0], p[len(p)-w.max:]...)
+
+		return len(p), nil
+	}
+
+	if overflow := len(w.buf) + len(p) - w.max; overflow > 0 {
+		n := copy(w.buf, w.buf[overflow:])
+		w.buf = w.buf[:n]
+	}
+
+	w.buf = append(w.buf, p...)
+
+	return len(p), nil
 }
 
 // tail returns the last n bytes of b (a copy), or all of b when shorter.

--- a/executor_internal_test.go
+++ b/executor_internal_test.go
@@ -1,0 +1,44 @@
+package invoke
+
+import "testing"
+
+// TestTailWriterKeepsNewestBytes pins the tail semantics: whatever the
+// write pattern, the buffer holds the newest max bytes, and Write always
+// accepts the full slice.
+func TestTailWriterKeepsNewestBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		max    int
+		writes []string
+		want   string
+	}{
+		{name: "under the bound", max: 8, writes: []string{"abc"}, want: "abc"},
+		{name: "accumulates across writes", max: 8, writes: []string{"abc", "def"}, want: "abcdef"},
+		{name: "overflow drops the oldest", max: 8, writes: []string{"abcdef", "ghij"}, want: "cdefghij"},
+		{name: "single write over the bound", max: 8, writes: []string{"0123456789"}, want: "23456789"},
+		{name: "write exactly at the bound", max: 8, writes: []string{"01234567"}, want: "01234567"},
+		{name: "empty write changes nothing", max: 8, writes: []string{"abc", ""}, want: "abc"},
+		{name: "many small writes", max: 4, writes: []string{"a", "b", "c", "d", "e", "f"}, want: "cdef"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := &tailWriter{max: tt.max}
+
+			for _, s := range tt.writes {
+				n, err := w.Write([]byte(s))
+				if err != nil || n != len(s) {
+					t.Fatalf("Write(%q) = (%d, %v), want (%d, nil)", s, n, err, len(s))
+				}
+			}
+
+			if got := string(w.buf); got != tt.want {
+				t.Fatalf("buf = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/executor_test.go
+++ b/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"testing"
@@ -30,6 +31,7 @@ type scriptOutcome struct {
 	err      error
 	startErr error  // returned from Start instead of a process
 	onStdout string // written to the attempt's Stdout before Wait
+	onStderr string // written to the attempt's Stderr before Wait
 }
 
 func (s *scriptEnv) Start(_ context.Context, _ invoke.Command, stdio invoke.IO) (invoke.Process, error) {
@@ -45,6 +47,10 @@ func (s *scriptEnv) Start(_ context.Context, _ invoke.Command, stdio invoke.IO) 
 
 	if out.onStdout != "" && stdio.Stdout != nil {
 		_, _ = stdio.Stdout.Write([]byte(out.onStdout))
+	}
+
+	if out.onStderr != "" && stdio.Stderr != nil {
+		_, _ = stdio.Stderr.Write([]byte(out.onStderr))
 	}
 
 	if out.startErr != nil {
@@ -387,6 +393,157 @@ func TestOutputAttachesStderrToExitError(t *testing.T) {
 	assert.Contains(t, string(exitErr.Stderr), "boom", "ExitError.Stderr must carry the captured stderr")
 }
 
+func TestRunAttachesStderrTailWhenStderrIsDiscarded(t *testing.T) {
+	t.Parallel()
+
+	env := fake.New()
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	exec := invoke.NewExecutor(env)
+
+	_, err := exec.Run(t.Context(), invoke.Shell("echo boom 1>&2; exit 3"), invoke.IO{})
+
+	var exitErr *invoke.ExitError
+
+	require.ErrorAs(t, err, &exitErr)
+
+	assert.Contains(t, string(exitErr.Stderr), "boom",
+		"a fire-and-forget failure must still say why")
+}
+
+func TestRunStderrTailNotAttachedWhenCallerClaimsStream(t *testing.T) {
+	t.Parallel()
+
+	env := fake.New()
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	exec := invoke.NewExecutor(env)
+
+	t.Run("caller's own writer", func(t *testing.T) {
+		t.Parallel()
+
+		var stderr strings.Builder
+
+		_, err := exec.Run(t.Context(), invoke.Shell("echo boom 1>&2; exit 3"), invoke.IO{Stderr: &stderr})
+
+		var exitErr *invoke.ExitError
+
+		require.ErrorAs(t, err, &exitErr)
+
+		assert.Empty(t, exitErr.Stderr, "stderr went to the caller's writer; the error must not duplicate it")
+		assert.Equal(t, "boom\n", stderr.String())
+	})
+
+	t.Run("explicit discard", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := exec.Run(t.Context(), invoke.Shell("echo boom 1>&2; exit 3"), invoke.IO{Stderr: io.Discard})
+
+		var exitErr *invoke.ExitError
+
+		require.ErrorAs(t, err, &exitErr)
+
+		assert.Empty(t, exitErr.Stderr, "io.Discard is the opt-out; nothing may be retained")
+	})
+}
+
+func TestRunStderrTailIsPerAttempt(t *testing.T) {
+	t.Parallel()
+
+	// The first attempt writes stderr and dies at transport; the retry
+	// writes its own stderr and exits non-zero. The tail must carry the
+	// failing attempt's stderr alone, not an accumulation.
+	env := &scriptEnv{outcome: []scriptOutcome{
+		{onStderr: "stale-from-attempt-1", err: transportErr()},
+		{onStderr: "fresh-from-attempt-2", err: &invoke.ExitError{Code: 7}},
+	}}
+
+	exec := invoke.NewExecutor(env, invoke.WithRetry(3, nil))
+
+	_, err := exec.Run(t.Context(), invoke.New("x"), invoke.IO{})
+
+	var exitErr *invoke.ExitError
+
+	require.ErrorAs(t, err, &exitErr)
+
+	assert.Equal(t, "fresh-from-attempt-2", string(exitErr.Stderr))
+}
+
+func TestRunStderrTailIsBounded(t *testing.T) {
+	t.Parallel()
+
+	// The bound is 8 KiB, and the newest bytes must be the ones kept.
+	noise := strings.Repeat("x", 9*1024)
+	env := &scriptEnv{outcome: []scriptOutcome{
+		{onStderr: noise + "END-OF-STDERR", err: &invoke.ExitError{Code: 1}},
+	}}
+
+	exec := invoke.NewExecutor(env)
+
+	_, err := exec.Run(t.Context(), invoke.New("x"), invoke.IO{})
+
+	var exitErr *invoke.ExitError
+
+	require.ErrorAs(t, err, &exitErr)
+
+	assert.Len(t, exitErr.Stderr, 8*1024)
+	assert.True(t, strings.HasSuffix(string(exitErr.Stderr), "END-OF-STDERR"),
+		"the tail must keep the newest bytes")
+}
+
+// TestRunStderrAtTheEnvironmentBoundary pins what the environment
+// receives: a tail writer in place of nil, except under a TTY, where
+// there is no separate stderr stream to retain.
+func TestRunStderrAtTheEnvironmentBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		stdio      invoke.IO
+		wantStderr bool
+	}{
+		{name: "nil stderr becomes the tail writer", stdio: invoke.IO{}, wantStderr: true},
+		{name: "tty leaves stderr alone", stdio: invoke.IO{TTY: &invoke.TTY{}}, wantStderr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var seen invoke.IO
+
+			env := &captureEnv{onIO: func(stdio invoke.IO) { seen = stdio }}
+			exec := invoke.NewExecutor(env)
+
+			_, err := exec.Run(t.Context(), invoke.New("x"), tt.stdio)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantStderr, seen.Stderr != nil)
+		})
+	}
+}
+
+func TestLinesAttachesStderrTailToExitError(t *testing.T) {
+	t.Parallel()
+
+	env := fake.New()
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	exec := invoke.NewExecutor(env)
+
+	_, err := exec.Lines(t.Context(), invoke.Shell("echo boom 1>&2; exit 3"), func(string) {})
+
+	var exitErr *invoke.ExitError
+
+	require.ErrorAs(t, err, &exitErr)
+
+	assert.Contains(t, string(exitErr.Stderr), "boom",
+		"Lines discards stderr from delivery, not from diagnostics")
+}
+
 func TestLinesDeliversEachLine(t *testing.T) {
 	t.Parallel()
 
@@ -419,13 +576,20 @@ func TestExecutorUploadRetriesTransportErrors(t *testing.T) {
 	assert.Equal(t, 3, env.uploads)
 }
 
-// captureEnv records the Command passed to Start and returns success.
+// captureEnv records what Start was asked for and returns success.
 type captureEnv struct {
 	onStart func(invoke.Command)
+	onIO    func(invoke.IO)
 }
 
-func (c *captureEnv) Start(_ context.Context, cmd invoke.Command, _ invoke.IO) (invoke.Process, error) {
-	c.onStart(cmd)
+func (c *captureEnv) Start(_ context.Context, cmd invoke.Command, stdio invoke.IO) (invoke.Process, error) {
+	if c.onStart != nil {
+		c.onStart(cmd)
+	}
+
+	if c.onIO != nil {
+		c.onIO(stdio)
+	}
 
 	return &scriptProcess{result: invoke.Result{ExitCode: 0}}, nil
 }

--- a/io.go
+++ b/io.go
@@ -23,9 +23,11 @@ type IO struct {
 	// Stdout receives the process's standard output. nil discards it.
 	Stdout io.Writer
 
-	// Stderr receives the process's standard error. nil discards it.
-	// Ignored when TTY is set: a pseudo-terminal merges standard error
-	// into standard output.
+	// Stderr receives the process's standard error. nil discards it,
+	// though the [Executor] retains a bounded tail of a failed command's
+	// standard error for its [ExitError]; pass [io.Discard] to discard
+	// unconditionally. Ignored when TTY is set: a pseudo-terminal merges
+	// standard error into standard output.
 	Stderr io.Writer
 
 	// TTY, when non-nil, allocates a pseudo-terminal for the process.


### PR DESCRIPTION
## What

Establishes one diagnostics invariant across the Executor:

> An `ExitError` carries a bounded tail (8 KiB) of the command's standard error unless the caller claimed the stream — by wiring their own `Stderr` writer, by requesting a TTY (which merges standard error into standard output), or by passing `io.Discard` to discard deliberately.

Previously only `Output` did this. The natural fire-and-forget call — `Run` with a zero `IO` — reported `process exited with code 1` and nothing else, and `Lines` discarded stderr entirely. The best-diagnosed way to run-and-discard was `Output` with three blank identifiers, which this repository's own tests carry a `//nolint:dogsled` for.

## Semantics

- **Per-attempt freshness**: under retry, the tail belongs to the failing attempt alone; a transport-failed attempt's stderr never leaks into the next attempt's error.
- **Bounded**: the newest 8 KiB win (`tailWriter` keeps a rolling tail, unlike `Output`'s full buffer — no unbounded memory).
- **Opt-out needs no special case**: `io.Discard` is a non-nil writer, so it reads as the caller claiming the stream.
- **TTY untouched**: with a TTY there is no separate stderr stream, so nothing is substituted.
- **Environments unaffected**: they receive an ordinary writer; providers and the contract suite are unchanged. `Output`'s existing attach is not disturbed (its per-attempt IO carries its own buffers, so the new path never engages).

## Testing

Every new test was proven capable of failing by defect injection, per CONTRIBUTING's rule:

| Injected defect | Caught by |
|---|---|
| One tail shared across retry attempts | `TestRunStderrTailIsPerAttempt` |
| Writer keeps the oldest bytes instead of the newest | `TestRunStderrTailIsBounded`, `TestTailWriterKeepsNewestBytes` |
| `Lines` forgets to attach | `TestLinesAttachesStderrTailToExitError` |

Plus: claimed-stream and `io.Discard` cases stay empty, the environment-boundary test pins what `Start` receives (tail writer for nil stderr, nil under TTY), and the existing `Output` tests hold. `just check` green (fmt, lint 0 issues both modules, tidy, Windows cross-build, `-race` everywhere).

## Context

This is non-breaking and makes `Run(ctx, cmd, invoke.IO{})` fully diagnostic on its own. A planned follow-up reshapes `Output` to `([]byte, error)` and adds `Text` plus package-level one-shots, leaning on this invariant to make discarding stderr safe everywhere.