### PR TITLE
feat(executor)!: Reshape capture around Text and Output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,15 @@ resolves to a major.
 Release notes are drafted automatically as pull requests merge, so a
 well-titled pull request is the changelog entry.
 
+## The convenience surface is closed
+
+A helper earns a place on the `Executor`, or as a package-level
+one-shot, only if nearly every consumer wants it, it cannot be composed
+from the existing surface in a couple of obvious lines, and the
+hand-rolled version hides a trap — lost diagnostics, retry-unsafe
+buffering. A proposal that fails any of the three belongs in the
+caller's code.
+
 ## Behavior is specified by contracts
 
 Provider behavior is enforced by the executable suite in `invoketest`,

--- a/README.md
+++ b/README.md
@@ -56,22 +56,23 @@ func main() {
 	}
 	defer env.Close()
 
-	_, out, _, err := invoke.NewExecutor(env).Output(
-		context.Background(), invoke.New("uname", "-s"))
+	out, err := invoke.Text(context.Background(), env, invoke.New("uname", "-s"))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Print(string(out))
+	fmt.Println(out)
 }
 ```
 
-An `Environment` is a connection to a target; an `Executor` wraps one and
-adds the policy most callers want — output capture, retries, sudo. A
-`Command` is a plain value with no streams and no state, so the same one
-runs repeatedly or against several targets; where output goes belongs to
-the invocation, not the command. Transfers ride the same environment:
-`exec.Upload(ctx, "./dist", "/srv/app")` copies a file or a whole tree.
+An `Environment` is a connection to a target; `invoke.Text` and
+`invoke.Run` execute one command on it. An `Executor` wraps an
+environment when several calls share policy — retries, sudo — so the
+defaults are stated once and every call inherits them. A `Command` is a
+plain value with no streams and no state, so the same one runs
+repeatedly or against several targets; where output goes belongs to the
+invocation, not the command. Transfers ride the same environment:
+`env.Upload(ctx, "./dist", "/srv/app")` copies a file or a whole tree.
 
 To run the same command elsewhere, construct a different target. A remote
 host authenticates with a key file, the agent (`ssh.WithAgent`), or a
@@ -104,7 +105,7 @@ Every failure answers one question first: did the command run? Branch on
 the kind, never the message:
 
 ```go
-_, err := exec.Run(ctx, invoke.Shell("systemctl restart app"), invoke.IO{})
+_, err := invoke.Run(ctx, env, invoke.Shell("systemctl restart app"), invoke.IO{})
 
 var exitErr *invoke.ExitError
 

--- a/doc.go
+++ b/doc.go
@@ -8,10 +8,11 @@
 //
 // # Getting started
 //
-// An [Environment] is a target. An [Executor] wraps one and adds the
-// policy most callers want: capturing output, retrying, running under
-// sudo. Constructing the target is the only line that changes between
-// them.
+// An [Environment] is a target; constructing it is the only line that
+// changes between local, ssh and docker. The package-level [Text] and
+// [Run] execute one command on it. An [Executor] wraps an environment
+// when several calls share policy — retry, sudo — so the defaults are
+// stated once.
 //
 //	env, err := local.New()          // or ssh.New(ctx, host, ...), docker.New(ctx, container, ...)
 //	if err != nil {
@@ -19,7 +20,7 @@
 //	}
 //	defer env.Close()
 //
-//	_, stdout, _, err := invoke.NewExecutor(env).Output(ctx, invoke.New("uname", "-s"))
+//	out, err := invoke.Text(ctx, env, invoke.New("uname", "-s"))
 //
 // [Command] is a plain value describing what to run. It carries no
 // streams and no state, so one can be run repeatedly, or against several

--- a/docker/upload_atomicity_test.go
+++ b/docker/upload_atomicity_test.go
@@ -42,7 +42,7 @@ func TestUploadStagesOnTheDestinationFilesystem(t *testing.T) {
 	require.NoError(t, env.Upload(t.Context(), local, "/data/payload.txt"),
 		"upload must stage on the destination's filesystem, not depend on /tmp being writable")
 
-	_, stdout, _, err := invoke.NewExecutor(env).Output(t.Context(), invoke.New("cat", "/data/payload.txt"))
+	stdout, err := invoke.NewExecutor(env).Output(t.Context(), invoke.New("cat", "/data/payload.txt"))
 	require.NoError(t, err, "reading the uploaded file")
 
 	assert.Equal(t, "delivered", string(stdout), "the upload did not arrive at the destination")
@@ -75,7 +75,7 @@ func TestUploadReplacesAnExistingDirectory(t *testing.T) {
 
 	require.NoError(t, env.Upload(t.Context(), srcDir, "/data/target"), "upload over an existing directory")
 
-	_, stdout, _, err := exec.Output(t.Context(), invoke.New("cat", "/data/target/new.txt"))
+	stdout, err := exec.Output(t.Context(), invoke.New("cat", "/data/target/new.txt"))
 	require.NoError(t, err, "reading the replacement content")
 	assert.Equal(t, "fresh", string(stdout), "the new content did not arrive")
 

--- a/example_test.go
+++ b/example_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ruffel/invoke"
 	"github.com/ruffel/invoke/fake"
@@ -15,6 +16,26 @@ import (
 
 // The quickstart, against a real target: constructing the environment is
 // the only line that differs between local, ssh and docker.
+func ExampleText() {
+	env, err := local.New()
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() { _ = env.Close() }()
+
+	out, err := invoke.Text(context.Background(), env, invoke.New("echo", "from the host"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(out)
+	// Output: from the host
+}
+
+// An Executor states policy once — here, retry with backoff — and every
+// call inherits it. For a single call with no shared defaults, the
+// package-level [Text] and [Run] need no Executor at all.
 func ExampleNewExecutor() {
 	env, err := local.New()
 	if err != nil {
@@ -23,13 +44,14 @@ func ExampleNewExecutor() {
 
 	defer func() { _ = env.Close() }()
 
-	_, stdout, _, err := invoke.NewExecutor(env).Output(
-		context.Background(), invoke.New("echo", "from the host"))
+	exec := invoke.NewExecutor(env, invoke.WithRetry(3, invoke.ExponentialBackoff(time.Second)))
+
+	out, err := exec.Text(context.Background(), invoke.New("echo", "from the host"))
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("%s", stdout)
+	fmt.Println(out)
 	// Output: from the host
 }
 
@@ -42,7 +64,7 @@ func ExampleExecutor_Output() {
 
 	exec := invoke.NewExecutor(env)
 
-	_, stdout, _, err := exec.Output(context.Background(), invoke.New("echo", "hello"))
+	stdout, err := exec.Output(context.Background(), invoke.New("echo", "hello"))
 	if err != nil {
 		panic(err)
 	}
@@ -59,7 +81,7 @@ func ExampleWithRetry() {
 
 	exec := invoke.NewExecutor(env, invoke.WithRetry(3, invoke.ConstantBackoff(0)))
 
-	res, _, _, err := exec.Output(context.Background(), invoke.Shell("exit 0"))
+	res, err := exec.Run(context.Background(), invoke.Shell("exit 0"), invoke.IO{})
 	fmt.Println(res.ExitCode, err)
 	// Output: 0 <nil>
 }
@@ -72,9 +94,7 @@ func ExampleExitError() {
 
 	defer func() { _ = env.Close() }()
 
-	exec := invoke.NewExecutor(env)
-
-	_, err := exec.Run(context.Background(), invoke.Shell("exit 3"), invoke.IO{})
+	_, err := invoke.Run(context.Background(), env, invoke.Shell("exit 3"), invoke.IO{})
 
 	var exitErr *invoke.ExitError
 
@@ -191,7 +211,7 @@ func ExampleEnvironment_Handle() {
 
 	exec := invoke.NewExecutor(env)
 
-	_, stdout, _, err := exec.Output(context.Background(), invoke.New("systemctl", "restart", "nginx"))
+	stdout, err := exec.Output(context.Background(), invoke.New("systemctl", "restart", "nginx"))
 	if err != nil {
 		panic(err)
 	}

--- a/exec_options.go
+++ b/exec_options.go
@@ -44,6 +44,8 @@ func WithRetry(attempts int, backoff BackoffFunc) Option {
 // WithFreshIO supplies a fresh [IO] for each attempt, so a retried command
 // gets un-consumed streams. It is required to retry a command whose IO
 // carries a non-nil Stdin, since a consumed reader cannot be replayed.
+// The capture helpers ([Executor.Output], [Executor.Text]) own their
+// streams and override any WithFreshIO passed to them.
 func WithFreshIO(fn func(attempt int) IO) Option {
 	return func(c *execConfig) {
 		c.freshIO = fn

--- a/executor.go
+++ b/executor.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 )
 
@@ -99,30 +100,42 @@ func (e *Executor) Run(ctx context.Context, cmd Command, stdio IO, opts ...Optio
 	})
 }
 
-// Output runs cmd and returns its captured stdout and stderr. It is
-// retry-safe by construction: each attempt writes into fresh buffers, so a
-// failed attempt's partial output never accumulates into the result. On an
-// [ExitError], a tail of stderr is attached for diagnostics.
-func (e *Executor) Output(ctx context.Context, cmd Command, opts ...Option) (Result, []byte, []byte, error) {
-	var stdout, stderr bytes.Buffer
+// Output runs cmd and returns its captured standard output — the exact
+// bytes, trailing newline included; [Executor.Text] is the form shaped
+// for reading the output as an answer. It is retry-safe by construction:
+// each attempt writes into a fresh buffer, so a failed attempt's partial
+// output never accumulates into the result. On a non-nil error the
+// returned bytes hold whatever standard output was captured, and an
+// [ExitError] carries a tail of standard error.
+func (e *Executor) Output(ctx context.Context, cmd Command, opts ...Option) ([]byte, error) {
+	var stdout bytes.Buffer
 
 	fresh := func(int) IO {
 		stdout.Reset()
-		stderr.Reset()
 
-		return IO{Stdout: &stdout, Stderr: &stderr}
+		return IO{Stdout: &stdout}
 	}
 
 	// Output owns the streams, so it forces its own fresh-IO provider
 	// after the caller's options (retry safety is not negotiable here).
-	res, err := e.Run(ctx, cmd, IO{}, append(opts, WithFreshIO(fresh))...)
+	// The IO it supplies carries no Stderr, so Run retains the tail an
+	// ExitError travels with.
+	_, err := e.Run(ctx, cmd, IO{}, append(opts, WithFreshIO(fresh))...)
 
-	var exitErr *ExitError
-	if errors.As(err, &exitErr) && len(exitErr.Stderr) == 0 {
-		exitErr.Stderr = tail(stderr.Bytes(), maxStderrTail)
-	}
+	return stdout.Bytes(), err
+}
 
-	return res, stdout.Bytes(), stderr.Bytes(), err
+// Text runs cmd and returns its standard output as a string with
+// trailing carriage returns and newlines removed — the shape wanted when
+// the output is an answer rather than data. Leading and interior
+// whitespace survive; use [Executor.Output] for the exact bytes.
+//
+// On a non-nil error the string holds whatever standard output was
+// captured, and an [ExitError] carries a tail of standard error.
+func (e *Executor) Text(ctx context.Context, cmd Command, opts ...Option) (string, error) {
+	out, err := e.Output(ctx, cmd, opts...)
+
+	return strings.TrimRight(string(out), "\r\n"), err
 }
 
 // Lines runs cmd and calls onLine for each line of its standard output.
@@ -424,13 +437,4 @@ func (w *tailWriter) Write(p []byte) (int, error) {
 	w.buf = append(w.buf, p...)
 
 	return len(p), nil
-}
-
-// tail returns the last n bytes of b (a copy), or all of b when shorter.
-func tail(b []byte, n int) []byte {
-	if len(b) <= n {
-		return bytes.Clone(b)
-	}
-
-	return bytes.Clone(b[len(b)-n:])
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -279,7 +279,7 @@ func TestOutputDoesNotAccumulateAcrossRetries(t *testing.T) {
 
 	exec := invoke.NewExecutor(env, invoke.WithRetry(3, nil))
 
-	_, stdout, _, err := exec.Output(t.Context(), invoke.New("x"))
+	stdout, err := exec.Output(t.Context(), invoke.New("x"))
 	require.NoError(t, err)
 
 	assert.Equal(t, "clean-attempt-2", string(stdout), "Output must return only the successful attempt's output")
@@ -367,12 +367,10 @@ func TestOutputAgainstFakeProvider(t *testing.T) {
 
 	exec := invoke.NewExecutor(env)
 
-	res, stdout, stderr, err := exec.Output(t.Context(), invoke.Shell("echo out; echo err 1>&2"))
+	stdout, err := exec.Output(t.Context(), invoke.Shell("echo out; echo err 1>&2"))
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, res.ExitCode)
-	assert.Equal(t, "out\n", string(stdout))
-	assert.Equal(t, "err\n", string(stderr))
+	assert.Equal(t, "out\n", string(stdout), "stderr must not leak into the captured stdout")
 }
 
 func TestOutputAttachesStderrToExitError(t *testing.T) {
@@ -384,13 +382,113 @@ func TestOutputAttachesStderrToExitError(t *testing.T) {
 
 	exec := invoke.NewExecutor(env)
 
-	_, _, _, err := exec.Output(t.Context(), invoke.Shell("echo boom 1>&2; exit 2")) //nolint:dogsled // Output returns four values; only the error matters here.
+	_, err := exec.Output(t.Context(), invoke.Shell("echo boom 1>&2; exit 2"))
 
 	var exitErr *invoke.ExitError
 
 	require.ErrorAs(t, err, &exitErr)
 
 	assert.Contains(t, string(exitErr.Stderr), "boom", "ExitError.Stderr must carry the captured stderr")
+}
+
+func TestTextTrimsTrailingNewlinesOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		stdout string
+		want   string
+	}{
+		{name: "trailing newline", stdout: "answer\n", want: "answer"},
+		{name: "trailing crlf", stdout: "answer\r\n", want: "answer"},
+		{name: "several trailing newlines", stdout: "answer\n\n\n", want: "answer"},
+		{name: "leading whitespace is data", stdout: "  indented\n", want: "  indented"},
+		{name: "interior newlines are data", stdout: "a\nb\n", want: "a\nb"},
+		{name: "trailing spaces are data", stdout: "answer \n", want: "answer "},
+		{name: "empty output", stdout: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := &scriptEnv{outcome: []scriptOutcome{{onStdout: tt.stdout}}}
+			exec := invoke.NewExecutor(env)
+
+			got, err := exec.Text(t.Context(), invoke.New("x"))
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTextReturnsPartialOutputAndTailOnExitError(t *testing.T) {
+	t.Parallel()
+
+	env := fake.New()
+
+	t.Cleanup(func() { _ = env.Close() })
+
+	exec := invoke.NewExecutor(env)
+
+	out, err := exec.Text(t.Context(), invoke.Shell("echo partial; echo boom 1>&2; exit 3"))
+
+	var exitErr *invoke.ExitError
+
+	require.ErrorAs(t, err, &exitErr)
+
+	assert.Equal(t, "partial", out, "stdout captured before the failure must be returned")
+	assert.Contains(t, string(exitErr.Stderr), "boom")
+}
+
+func TestTextIsRetrySafe(t *testing.T) {
+	t.Parallel()
+
+	// The first attempt writes partial output then dies at transport;
+	// the retry writes the real answer. Per-call options must reach the
+	// underlying capture, and its buffer must be fresh per attempt.
+	env := &scriptEnv{outcome: []scriptOutcome{
+		{onStdout: "PARTIAL-FROM-ATTEMPT-1", err: transportErr()},
+		{onStdout: "clean-attempt-2\n"},
+	}}
+
+	exec := invoke.NewExecutor(env)
+
+	got, err := exec.Text(t.Context(), invoke.New("x"), invoke.WithRetry(3, nil))
+	require.NoError(t, err)
+
+	assert.Equal(t, "clean-attempt-2", got)
+}
+
+func TestOneShotRunAppliesOptions(t *testing.T) {
+	t.Parallel()
+
+	env := &scriptEnv{outcome: []scriptOutcome{
+		{err: transportErr()},
+		{result: invoke.Result{ExitCode: 0}},
+	}}
+
+	res, err := invoke.Run(t.Context(), env, invoke.New("x"), invoke.IO{}, invoke.WithRetry(3, nil))
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, res.ExitCode)
+	assert.Equal(t, 2, env.startCount(), "options must reach the underlying executor")
+}
+
+func TestOneShotTextAppliesOptions(t *testing.T) {
+	t.Parallel()
+
+	env := &scriptEnv{outcome: []scriptOutcome{
+		{err: transportErr()},
+		{onStdout: "ok\n"},
+	}}
+
+	got, err := invoke.Text(t.Context(), env, invoke.New("x"), invoke.WithRetry(3, nil))
+	require.NoError(t, err)
+
+	assert.Equal(t, "ok", got)
+	assert.Equal(t, 2, env.startCount(), "options must reach the underlying executor")
 }
 
 func TestRunAttachesStderrTailWhenStderrIsDiscarded(t *testing.T) {

--- a/oneshot.go
+++ b/oneshot.go
@@ -1,0 +1,18 @@
+package invoke
+
+import "context"
+
+// Run starts cmd on env with the given IO, waits for it, and returns the
+// outcome. It is the one-shot form of [Executor.Run]; construct an
+// Executor to state retry or sudo defaults once and share them across
+// calls.
+func Run(ctx context.Context, env Environment, cmd Command, stdio IO, opts ...Option) (Result, error) {
+	return NewExecutor(env).Run(ctx, cmd, stdio, opts...)
+}
+
+// Text runs cmd on env and returns its standard output as a string with
+// trailing carriage returns and newlines removed. It is the one-shot
+// form of [Executor.Text].
+func Text(ctx context.Context, env Environment, cmd Command, opts ...Option) (string, error) {
+	return NewExecutor(env).Text(ctx, cmd, opts...)
+}


### PR DESCRIPTION
## What

The capture surface becomes a ladder where each rung has a distinct return shape and a distinct question it answers:

| Call | Returns | For |
|---|---|---|
| `Text` *(new)* | `(string, error)` | the output is an answer — trailing newlines trimmed |
| `Output` *(reshaped)* | `([]byte, error)` | the output is data — exact bytes |
| `Run` | `(Result, error)` | you own the streams and want the `Result` |
| `Lines` | `(Result, error)` | the output is a stream |

Package-level one-shots `invoke.Text(ctx, env, cmd, opts...)` and `invoke.Run(ctx, env, cmd, stdio, opts...)` cover the single-call case with no `Executor` construction — an `Executor` holds no resources, so the one-shot form costs nothing, and the quickstart becomes:

```go
out, err := invoke.Text(ctx, env, invoke.New("uname", "-s"))
```

## Breaking change

`Executor.Output` drops its `Result` and stderr returns: `(Result, []byte, []byte, error)` → `([]byte, error)`. Migration:

- `_, stdout, _, err := exec.Output(...)` → `stdout, err := exec.Output(...)` — every call site in this repository had this shape (one carried a `//nolint:dogsled`), and all got simpler.
- Stderr as diagnostics: already on the `ExitError` — its bounded tail is attached whenever the caller does not claim the stream, so nothing is lost by not returning it.
- Stderr as data, or the `Result`: wire your own writers through `Run`; `WithFreshIO` exists for exactly that under retry.

Pre-1.0 policy: lands as a called-out minor (v0.6.0).

## Semantics pinned by tests

- **Trim rule**: `TrimRight(s, "\r\n")` — trailing newlines are framing; leading whitespace, interior newlines, and trailing spaces are data and survive. The table's whitespace cases fail under a `TrimSpace` implementation.
- **Partial output on error**: `Text`/`Output` return whatever stdout was captured alongside the error, with the stderr tail on the `ExitError`.
- **Retry safety inherited**: fresh buffer per attempt; per-call options flow through the one-shots and `Text` (proven by defect injection: dropping `opts` in either fails its test).
- **`WithFreshIO` documented as owned**: capture helpers override it rather than silently interleaving.

CONTRIBUTING gains a "convenience surface is closed" note recording the bar a future helper must clear.

## Verification

`just check` green (exit 0 confirmed): fmt, lint 0 issues both modules, tidy, Windows cross-build, `-race` everywhere. Build-tagged integration files (`docker`, `openssh`) vet clean. Both README fenced blocks compile against this tree, and the quickstart runs (`Darwin`). Doc examples execute the real local provider (`ExampleText` runs `echo` end to end). Defect injections: `TrimSpace` caught by the trim table, dropped options caught by the retry-safety and one-shot tests.