### PR TITLE
build(just): Lint the tests that only compile under a build tag

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -75,10 +75,17 @@ test-parity:
 # of `check`.
 test-integration: test-docker test-openssh
 
-# Run linters across every module.
+# Run linters across every module, including the tests behind build tags.
+#
+# The integration tests compile only under their tags, so a run without
+# them lints neither the openssh lane nor the docker one — a thousand
+# lines that CI checks and `check` could not fail on. The docker module's
+# tagged run is a superset of its untagged one, so it replaces it.
 lint:
+    golangci-lint config verify
     golangci-lint run ./...
-    cd docker && golangci-lint run ./...
+    golangci-lint run --build-tags openssh ./ssh/
+    cd docker && golangci-lint run --build-tags docker ./...
 
 # Apply the configured formatters (gofumpt, gci).
 fmt:


### PR DESCRIPTION
`check` ran the linter without build tags, so the openssh and docker
integration tests — six files, a thousand lines — were linted by CI and
by nothing a contributor could run. A change to one of them passed
`check` and failed the Lint job, which reads as a flaky CI rather than a
gap in the gate.

CI has always run these three invocations (ci.yml); the Justfile only
ever ran two of the five. Add them, so the two are what the header of
each file says they are: the same commands.

The docker module's tagged run is a superset of its untagged one — a
build tag adds files, it never removes them — so it replaces rather than
joins it. All four pass on this tree; the recipe is additive, not a fix
for anything currently failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)