### PR TITLE
build(ci): Run the docker module's tests, not just its build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,13 @@ jobs:
           go-version-file: go.mod
       - name: Run tests with race detector
         run: go test -race ./...
-      - name: Build the docker module
-        run: cd docker && go build ./...
+      # The contracts that need a daemon are behind the docker build tag
+      # and run in the integration lane. What is left is ordinary unit
+      # tests — tar building, path classification, context resolution —
+      # which need nothing and were the only part of this module never
+      # run on macOS.
+      - name: Run the docker module's tests with race detector
+        run: cd docker && go test -race ./...
 
   lint:
     name: Lint


### PR DESCRIPTION
The test job built the submodule and stopped there, so its 34 unit
tests — the ones needing no daemon — ran on neither runner. On macOS
they ran nowhere at all; on Linux only the container-gated integration
lane reached them, as a side effect of the docker tag being a superset.
A green "Test (macos-latest)" meant "the docker module compiles".

They are daemon-free: with DOCKER_HOST pointed at a socket that does not
exist the package still passes in under two seconds. Run them the way
`just test-race` already does, which is what the header of both files
claims is true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)