### PR TITLE
build(ci): Verify against the toolchain floor and the current release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,32 @@ concurrency:
 
 jobs:
   test:
-    name: Test (${{ matrix.os }})
+    name: Test (${{ matrix.os }}, Go ${{ matrix.go }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        # README promises "Go 1.25 or newer", which is two claims. The
+        # floor leg installs exactly what go.mod declares, so the promised
+        # minimum cannot rot; the stable leg installs the current release,
+        # so a newer toolchain cannot break the tree unnoticed. Neither
+        # version is written here: the floor is read from go.mod, so
+        # raising it needs no edit to this file.
+        go: [floor, stable]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Install the toolchain go.mod declares
+        if: matrix.go == 'floor'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+      - name: Install the current Go release
+        if: matrix.go == 'stable'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: stable
       - name: Run tests with race detector
         run: go test -race ./...
       - name: Build the docker module


### PR DESCRIPTION
Every job installed the toolchain go.mod names, so all seven resolved
go1.25.0 and the matrix varied only the operating system. README promises
"Go 1.25 or newer" — two claims, of which CI checked one. A break
introduced by a newer toolchain would have reached a release untested.

Add a toolchain dimension to the test lane. The floor leg keeps reading
go.mod, so raising the declared minimum needs no edit here and the two
cannot drift; the stable leg names the current release. Two steps behind
an `if` rather than one interpolated version, so neither leg depends on
how setup-go resolves an empty input against a version file.

Lint and the cross-build stay on the floor: they answer questions that do
not vary by patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)