### PR TITLE
docs: Show the stderr tail where a newcomer looks for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ var exitErr *invoke.ExitError
 switch {
 case err == nil: // ran and exited zero
 case errors.As(err, &exitErr): // ran and failed; the exit status is trustworthy
-	log.Printf("restart failed with exit %d", exitErr.Code)
+	// Stderr holds a tail of the command's own diagnostics, kept
+	// whenever the caller did not claim the stream.
+	log.Printf("restart failed with exit %d: %s", exitErr.Code, exitErr.Stderr)
 case errors.Is(err, invoke.ErrNotFound): // could not start: no such executable
 default: // everything else, including transport — the only family retries re-run
 	log.Print(err)

--- a/example_test.go
+++ b/example_test.go
@@ -94,19 +94,22 @@ func ExampleExitError() {
 
 	defer func() { _ = env.Close() }()
 
-	_, err := invoke.Run(context.Background(), env, invoke.Shell("exit 3"), invoke.IO{})
+	_, err := invoke.Run(context.Background(), env, invoke.Shell("echo boom >&2; exit 3"), invoke.IO{})
 
 	var exitErr *invoke.ExitError
 
 	switch {
 	case errors.As(err, &exitErr):
-		fmt.Println("ran and failed with", exitErr.Code)
+		// Stderr carries a tail of the command's own diagnostics. The
+		// Executor attaches it whenever the caller did not claim the
+		// stream, so a failure says why and not just how much.
+		fmt.Printf("ran and failed with %d: %s", exitErr.Code, exitErr.Stderr)
 	case errors.Is(err, invoke.ErrNotFound):
 		fmt.Println("could not be started")
 	case err != nil:
 		fmt.Println("something else went wrong")
 	}
-	// Output: ran and failed with 3
+	// Output: ran and failed with 3: boom
 }
 
 // A missing executable is reported before anything runs, so it is never

--- a/executor.go
+++ b/executor.go
@@ -34,9 +34,9 @@ const (
 // standard output), or by passing [io.Discard] to discard deliberately.
 //
 // Only the operations that carry policy are exposed here (Run, Output,
-// Lines, Upload, Download). For LookPath, OS, Capabilities, or Close, use
-// the Environment directly; if you need no policy at all, you need no
-// Executor.
+// Text, Lines, Upload, Download). For LookPath, OS, Capabilities, or
+// Close, use the Environment directly; if you need no policy at all, you
+// need no Executor.
 type Executor struct {
 	env  Environment
 	base execConfig


### PR DESCRIPTION
Attaching a tail of the command's standard error to ExitError was the
point of 447cffc, and neither README.md, doc.go nor any example
mentioned the field. A reader's first failing command printed an exit
code and nothing about why, which is what the feature exists to prevent.
It matters most on the fake, whose whole refusal strategy is to fail
loudly on standard error.

Print it in the README's failure block and in ExampleExitError, which
now runs a command that writes to standard error so the tail has
something to show rather than a demonstration of an empty field.

ExitError.Error() is left alone. os/exec's returns only the status too,
and callers may already match on the string.

Also add Text to the list of policy-carrying methods on Executor, which
83bcd08 added without updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)