### PR TITLE
test: Build the POSIX-only tests only on POSIX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,14 @@ jobs:
           go-version-file: go.mod
       - name: Cross-build for Windows
         run: GOOS=windows go build ./...
+      # `go build` does not compile _test.go files, so vet as well: it is
+      # what notices a test reaching for a POSIX-only symbol.
+      - name: Typecheck for Windows, tests included
+        run: GOOS=windows go vet ./...
       - name: Cross-build the docker module for Windows
         run: cd docker && GOOS=windows go build ./...
+      - name: Typecheck the docker module for Windows, tests included
+        run: cd docker && GOOS=windows go vet ./...
 
   # The unit lane runs the SSH provider against a server written for these
   # tests, which can only confirm what this repository already believes.

--- a/Justfile
+++ b/Justfile
@@ -37,9 +37,15 @@ build:
 
 # Cross-build for Windows: everything must compile there, even though
 # execution semantics are POSIX-only this cycle.
+#
+# vet as well as build, because `go build` does not compile _test.go
+# files: a test using a POSIX-only symbol left the claim false in the one
+# place neither this recipe nor CI could see it.
 build-windows:
     GOOS=windows go build ./...
+    GOOS=windows go vet ./...
     cd docker && GOOS=windows go build ./...
+    cd docker && GOOS=windows go vet ./...
 
 # Run tests. The docker provider's contracts need a daemon and are behind
 # a build tag; see test-docker.

--- a/local/fifo_unix_test.go
+++ b/local/fifo_unix_test.go
@@ -1,0 +1,10 @@
+//go:build unix
+
+package local_test
+
+import "syscall"
+
+// makeFIFO creates a named pipe for the special-file tests.
+func makeFIFO(path string, mode uint32) error {
+	return syscall.Mkfifo(path, mode)
+}

--- a/local/fifo_windows_test.go
+++ b/local/fifo_windows_test.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package local_test
+
+import "errors"
+
+// makeFIFO reports that named pipes are unavailable, so the special-file
+// tests skip. Windows is a cross-compilation target for this repository
+// rather than an execution one; the stub exists so the package still
+// typechecks there.
+func makeFIFO(string, uint32) error {
+	return errors.New("named pipes are not available on Windows")
+}

--- a/local/files_test.go
+++ b/local/files_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/ruffel/invoke"
@@ -326,7 +325,7 @@ func TestSpecialFilesErrorByDefaultAndSkipOnRequest(t *testing.T) {
 	writeFixture(t, srcDir, "normal.txt", "normal", modeDefault)
 
 	fifo := filepath.Join(srcDir, "pipe.fifo")
-	if err := syscall.Mkfifo(fifo, uint32(modeDefault)); err != nil {
+	if err := makeFIFO(fifo, uint32(modeDefault)); err != nil {
 		t.Skipf("mkfifo unavailable: %v", err)
 	}
 

--- a/ssh/signals_windows_test.go
+++ b/ssh/signals_windows_test.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package ssh_test
+
+import (
+	"os"
+	"syscall"
+)
+
+// sigTERM is the SSH name for SIGTERM, used as the default when a host
+// signal has no portable name.
+const sigTERM = "TERM"
+
+// signalToSyscall reports that no host signal is available. Windows is a
+// cross-compilation target for this repository rather than an execution
+// one, so the test server never delivers one; the stub exists so the
+// package still typechecks there.
+func signalToSyscall(string) (os.Signal, bool) {
+	return nil, false
+}
+
+// sysToSignalName answers with the default name, for the same reason: a
+// Windows host reports no signalled exit for the server to translate.
+func sysToSignalName(syscall.Signal) string {
+	return sigTERM
+}


### PR DESCRIPTION
README says everything compiles on Windows, and two test packages did
not: local/files_test.go reached for syscall.Mkfifo and
ssh/testserver_test.go called signalToSyscall, which is defined in a file
built only on unix. `GOOS=windows go vet ./...` failed on both.

Neither gate could see it. `go build` does not compile _test.go files, so
the cross-build lane — the one job whose whole purpose is that claim —
was structurally unable to fail on it, locally or in CI.

Split both behind build tags, the way invoketest already handles the same
FIFO problem, and add a vet pass to the lane so the claim is checked
where it is made. The Windows stubs skip rather than pretend: Windows is
a cross-compilation target for this repository, not an execution one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)